### PR TITLE
Changes the link references to "master" instead of a specific old branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ An example config file is included here: [example-config.json](example-config.js
 
 ---
 
-Check out [this example PDF](https://github.com/j6k4m8/goosepaper/blob/71ee16e91840560fe40234493a02a283cb84083f/docs/Example-Nov-1-2020.pdf), generated on Nov 1 2020.
+Check out [this example PDF](https://github.com/j6k4m8/goosepaper/blob/master/docs/Example-Nov-1-2020.pdf), generated on Nov 1 2020.
 
 ## existing story providers (want to write your own?)
 
--   [Wikipedia Top News / Current Events](https://github.com/j6k4m8/goosepaper/blob/71ee16e91840560fe40234493a02a283cb84083f/goosepaper/__init__.py#L112)
--   [Tweets](https://github.com/j6k4m8/goosepaper/blob/71ee16e91840560fe40234493a02a283cb84083f/goosepaper/__init__.py#L154) (Note: Currently borked, see [Issue #5](https://github.com/j6k4m8/goosepaper/issues/5))
--   [Weather](https://github.com/j6k4m8/goosepaper/blob/71ee16e91840560fe40234493a02a283cb84083f/goosepaper/__init__.py#L258). These stories appear in the "ear" of the front page, just like a regular ol' newspaper
--   [RSS Feeds](https://github.com/j6k4m8/goosepaper/blob/71ee16e91840560fe40234493a02a283cb84083f/goosepaper/__init__.py#L283)
--   [Reddit Subreddits](https://github.com/j6k4m8/goosepaper/blob/71ee16e91840560fe40234493a02a283cb84083f/goosepaper/__init__.py#L307)
+-   [Wikipedia Top News / Current Events](https://github.com/j6k4m8/goosepaper/blob/master/goosepaper/__init__.py#L112)
+-   [Tweets](https://github.com/j6k4m8/goosepaper/blob/master/goosepaper/__init__.py#L154) (Note: Currently borked, see [Issue #5](https://github.com/j6k4m8/goosepaper/issues/5))
+-   [Weather](https://github.com/j6k4m8/goosepaper/blob/master/goosepaper/__init__.py#L258). These stories appear in the "ear" of the front page, just like a regular ol' newspaper
+-   [RSS Feeds](https://github.com/j6k4m8/goosepaper/blob/master/goosepaper/__init__.py#L283)
+-   [Reddit Subreddits](https://github.com/j6k4m8/goosepaper/blob/master/goosepaper/__init__.py#L307)
 
 # More Questions, Infrequently Asked
 


### PR DESCRIPTION
I went to go add the F to C conversion in the weather story provider only to find it already existed! Turns out the link to the weather provider in the README went to an old version of the code, so I've updated the links to point at master instead. If there's some reason to point at the old version, feel free to just close this, but having it point at master might help other people not be confused.