### PR TITLE
alpine-based Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.github
+.git
+.DS_Store
+docs
+Dockerfile
+*.pdf
+*.json

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,37 @@
+FROM alpine:3.12
+
+LABEL maintainer="Sergio Moura <sergio@moura.ca>"
+
+RUN apk --update --no-cache add cairo libffi libjpeg libstdc++ libxml2 libxslt pango \
+py3-aiohttp py3-cffi py3-feedparser py3-gobject3 py3-html5lib py3-lxml py3-multidict \
+py3-numpy py3-requests py3-yarl ttf-dejavu
+
+# Panda
+ARG PANDAS_VERSION=1.1.5
+RUN apk add --no-cache --virtual .build-deps curl build-base linux-headers py3-pip py3-numpy-dev python3-dev py3-setuptools && \
+pip3 install cython && \
+cd /tmp && \
+curl -LO https://github.com/pandas-dev/pandas/releases/download/v${PANDAS_VERSION}/pandas-${PANDAS_VERSION}.tar.gz && \
+tar zxf pandas-${PANDAS_VERSION}.tar.gz && \
+cd pandas-${PANDAS_VERSION} && \
+python3 setup.py build && \
+python3 setup.py install --prefix=/usr && \
+cd /tmp && \
+rm -rf pandas-${PANDAS_VERSION}.tar.gz pandas-${PANDAS_VERSION} && \
+pip3 uninstall -y cython && \
+apk del .build-deps && \
+rm -Rf /root/.cache
+
+WORKDIR /app
+COPY requirements.txt .
+RUN apk add --no-cache --virtual .build-deps build-base git libxml2-dev libxslt-dev libffi-dev libjpeg-turbo-dev py3-pip py3-wheel python3-dev && \
+pip3 install -r ./requirements.txt && \
+apk del .build-deps && \
+rm -Rf /root/.cache
+COPY . .
+RUN apk add --no-cache --virtual .install-deps py3-pip && \
+pip3 install -e . && \
+apk del .install-deps && \
+rm -Rf /root/.cache
+
+ENTRYPOINT ["goosepaper"]


### PR DESCRIPTION
Would the project be interested in an alpine-based Docker image?

It takes a while to complete because it needs to compile stuff but the end result is an image with less than half the size (395MB vs 1.09GB)

The usage would be something like:

`docker run --rm -v $(pwd):/data j6k4m8/goosepaper:alpine -c /data/example-config.json -o /data/output.pdf`

It also uses the current files on the filesystem instead of downloading the files from github.

The build is made with reusability and size in mind:
* during development, if you're building the image over and over again, only the last few steps are going to be executed
* no build dependencies are ever committed to the docker image, keeping the size small
* whenever building for new versions, the dependencies part will most likely remain unchanged, so the first few steps will be reused

If you'd like to use the new dockerfile:
* Feel free to change the maintainer tag if you like
* Feel free to test it using the image that I've build on dockerhub: https://hub.docker.com/r/lsmoura/goosepaper (using `docker pull lsmoura/goosepaper:0.3.0`)
