### PR TITLE
Allow optional single-threaded RSS fetching

### DIFF
--- a/docs/Customizing.md
+++ b/docs/Customizing.md
@@ -177,7 +177,7 @@ The parameters are as follows:
 ```json
 	"rss_path"	:	"https://feeds.npr.org/1001/rss.xml" (str 	- RSS feed you want to see results from.)
 	"limit"		:	20 				(int 	- Amount of reddit headlines to provide.)
-	"paralell"	:	true 			(bool 	- Whether to use multiprocessing to fetch in parallel)
+	"parallel"	:	true 			(bool 	- Whether to use multiprocessing to fetch in parallel)
 ```
 
 ### <a name="Twitter">Twitter</a>

--- a/docs/Customizing.md
+++ b/docs/Customizing.md
@@ -27,7 +27,7 @@ As an example we give the config delivered as an example `example-config.json`:
         {
             "provider": "rss",
             "config": {
-                "rss_path": "https://www.npr.org/feed/",
+                "rss_path": "https://feeds.npr.org/1001/rss.xml",
                 "limit": 5
             }
         },
@@ -43,7 +43,7 @@ As an example we give the config delivered as an example `example-config.json`:
 }
 ```
 
-## Titles and fontsize
+## Titles and font Size
 
 In the first part of the config you can set global parameters for your goosepaper.
 These do not need to be set as they have default parameters.
@@ -51,7 +51,8 @@ These do not need to be set as they have default parameters.
 ### Title
 
 The title is at the top of the first page if your paper.
-Default value is 
+Default value is
+
 ```json
 "title" : "Daily Goosepaper"
 ```
@@ -59,33 +60,36 @@ Default value is
 ### Subtitle
 
 The subtitle is at the second line at the top of the first page after yout title.
-Default value is 
+Default value is
+
 ```json
 "subtitle" : ""
 ```
 
-### Fontsize
+### Font Size
 
-The fontsize determines the fontsize for all text in the goosepaper, but not the title, subtitle, or weather if this is set in `stories` (covered later). The default value is 
+The fontsize determines the fontsize for all text in the goosepaper, but not the title, subtitle, or weather if this is set in `stories` (covered later). The default value is
+
 ```json
 "font_size" : 14
 ```
+
 (This only matters if your output is set as a `.pdf`)
-  
+
 ## Style
 
 Something about styles needs to go here!!!
 
-## Stories and Storyproviders
+## Stories and StoryProviders
 
-The stories is the content you read in your goosepaper, and can be customized in a variety of ways.  
-  
-This section aims to be a comprehensive list of all storyproviders and how to configure them.  
-(This was the case at time of writing.)  
-  
+The stories is the content you read in your goosepaper, and can be customized in a variety of ways.
+
+This section aims to be a comprehensive list of all storyproviders and how to configure them.
+(This was the case at time of writing.)
+
 In addition to the storyproviders listed here, there is also a separate repository, [auxilliary-goose](https://github.com/j6k4m8/auxiliary-goose/), where you can find additional storyproviders. For info on how to customize these check out the documentation in said repository.
 
-Stories and storyproviders are given in the config-file using the `"stories"`-key in the following way:  
+Stories and storyproviders are given in the config-file using the `"stories"`-key in the following way:
 (remember correct comma-separation in this file).
 
 ```json
@@ -94,123 +98,136 @@ Stories and storyproviders are given in the config-file using the `"stories"`-ke
 		"provider" 	: "Storyprovider 1",
 		"config" 	: {
 			"PARAMETER"	: "VALUE",
-			"PARAMETER"	: "VALUE" 
+			"PARAMETER"	: "VALUE"
 		}
 	},
 	{
 		"provider" 	: "Storyprovider 2",
 		"config" 	: {
 			"PARAMETER"	: "VALUE",
-			"PARAMETER"	: "VALUE" 
+			"PARAMETER"	: "VALUE"
 		}
 	},
 ]
 ```
-  
+
 As per now these storyproviders are available:
-- [Lorem Ipsum](#LoremIpsum)
-- [Reddit](#Reddit)
-- [RSS](#RSS)
-- [Twitter](#Twitter)
-- [Weather](#Weather)
-- [Wikipedia Current Events](#Wikipedia)
-  
+
+-   [Lorem Ipsum](#LoremIpsum)
+-   [Reddit](#Reddit)
+-   [RSS](#RSS)
+-   [Twitter](#Twitter)
+-   [Weather](#Weather)
+-   [Wikipedia Current Events](#Wikipedia)
+
 ### <a name="LoremIpsum">Lorem Ipsum</a>
 
 This storyprovider fills paragraphs with Lorem Ipsum, and is mainly used for testing.
-  
+
 Default limiting value is `5`.
 
-Storyprovider name is 
+Storyprovider name is
+
 ```json
 	"provider"	: "lorem"
 ```
 
 The parameters are as follows:
-```json	
-	"limit"		:	5 	(int 	- Amount of Lorem Ipsum articles to provide.) 
+
+```json
+	"limit"		:	5 	(int 	- Amount of Lorem Ipsum articles to provide.)
 ```
-  
+
 ### <a name="Reddit">Reddit</a>
 
-This storyprovider gives headlines from a selected subreddit given in config file.  
+This storyprovider gives headlines from a selected subreddit given in config file.
 The story gives the title, the user and some text.
-  
-The parameter `subreddit` has to be given a value in configfile.  
-Default limiting value is `20`.  
 
-Storyprovider name is 
+The parameter `subreddit` has to be given a value in configfile.
+Default limiting value is `20`.
+
+Storyprovider name is
+
 ```json
 	"provider"	: "reddit"
 ```
 
 The parameters are as follows:
-```json	
-	"subreddit"	:	"news"	(str 	- Subreddit you want to see headlines from.) 
-	"limit"		:	20 	(int 	- Amount of reddit headlines to provide.) 
+
+```json
+	"subreddit"	:	"news"	(str 	- Subreddit you want to see headlines from.)
+	"limit"		:	20 	(int 	- Amount of reddit headlines to provide.)
 ```
 
 ### <a name="RSS">RSS</a>
 
-Returns results from a given RSS feed. This has to be specified in config file.  
-  
-The parameter `rss_path` has to be given a value in configfile.  
-Default limiting value is `5`.  
-  
-Storyprovider name is 
+Returns results from a given RSS feed. This has to be specified in config file.
+
+The parameter `rss_path` has to be given a value in configfile.
+Default limiting value is `5`.
+
+Storyprovider name is
+
 ```json
 	"provider"	: "rss"
 ```
 
 The parameters are as follows:
-```json	
-	"rss_path"	:	"https://www.npr.org/feed/"	(str 	- RSS feed you want to see results from.) 
-	"limit"		:	20 				(int 	- Amount of reddit headlines to provide.) 
+
+```json
+	"rss_path"	:	"https://feeds.npr.org/1001/rss.xml" (str 	- RSS feed you want to see results from.)
+	"limit"		:	20 				(int 	- Amount of reddit headlines to provide.)
+	"paralell"	:	true 			(bool 	- Whether to use multiprocessing to fetch in parallel)
 ```
 
 ### <a name="Twitter">Twitter</a>
 
-Returns tweets from given users. These have to be specified in config file.  
-  
-The parameter `usernames` has to be given a value in configfile.  
-Default limiting value is `8`.  
-  
-Storyprovider name is 
+Returns tweets from given users. These have to be specified in config file.
+
+The parameter `usernames` has to be given a value in configfile.
+Default limiting value is `8`.
+
+Storyprovider name is
+
 ```json
 	"provider"	: "twitter"
 ```
 
 The parameters are as follows:
-```json	
-	"usernames"	:	["axios", "NPR"]	([str] 	- Users you want to see results from.) 
-	"limit"		:	8 			(int 	- Amount of reddit headlines to provide.) 
+
+```json
+	"usernames"	:	["axios", "NPR"]	([str] 	- Users you want to see results from.)
+	"limit"		:	8 			(int 	- Amount of reddit headlines to provide.)
 ```
 
 ### <a name="Weather">Weather</a>
 
-Storyprovider for the weatherforecast on the first page.  
-The weatherdata for this storyprovider is collected from [www.metaweather.com](https://www.metaweather.com/).  
-  
+Storyprovider for the weatherforecast on the first page.
+The weatherdata for this storyprovider is collected from [www.metaweather.com](https://www.metaweather.com/).
+
 With `example-config.json` the forecast will look something like this:
-![Weather forcast with `example-config.json`](exampleWeather.png)  
-  
-Storyprovider name is 
+![Weather forcast with `example-config.json`](exampleWeather.png)
+
+Storyprovider name is
+
 ```json
 	"provider"	: "weather"
 ```
 
 The parameters are as follows:
-```json	
-	"woe"		:	2358820 	(int 	- Where On Earth, can be collected from 
-							  www.metaweather.com. Default is forBoston)
+
+```json
+	"woe"		:	2358820 	(int 	- Where On Earth, can be collected from
+							  www.metaweather.com.)
 	"F"		:	true/false	(bool 	- Fahreheit(true) or Celsius(false))
 ```
 
 ### <a name="Wikipedia">Wikipedia Current Events</a>
 
-Returns current events section from Wikipedia. These have to be specified in config file.  
-  
-Storyprovider name is 
+Returns current events section from Wikipedia. These have to be specified in config file.
+
+Storyprovider name is
+
 ```json
 	"provider"	: "wikipedia_current_events"
 ```

--- a/example-config.json
+++ b/example-config.json
@@ -19,7 +19,7 @@
         {
             "provider": "rss",
             "config": {
-                "rss_path": "https://www.npr.org/feed/",
+                "rss_path": "https://feeds.npr.org/1001/rss.xml",
                 "limit": 5
             }
         },

--- a/goosepaper/rss.py
+++ b/goosepaper/rss.py
@@ -10,16 +10,22 @@ from .storyprovider import StoryProvider
 
 
 class RSSFeedStoryProvider(StoryProvider):
-    def __init__(self, rss_path: str, limit: int = 5) -> None:
+    def __init__(self, rss_path: str, limit: int = 5, parallel: bool = True) -> None:
         self.limit = limit
         self.feed_url = rss_path
+        self._parallel = parallel
 
     def get_stories(self, limit: int = 5) -> List[Story]:
         feed = feedparser.parse(self.feed_url)
         limit = min(limit, self.limit, len(feed.entries))
+        if limit == 0:
+            print(f"Sad honk :/ No entries found for feed {self.feed_url}...")
 
-        with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
-            stories = pool.map(self.parallelizable_request, feed.entries[:limit])
+        if self._parallel:
+            with multiprocessing.Pool(multiprocessing.cpu_count()) as pool:
+                stories = pool.map(self.parallelizable_request, feed.entries[:limit])
+        else:
+            stories = [self.parallelizable_request(e) for e in feed.entries[:limit]]
 
         return list(filter(None, stories))
 
@@ -31,7 +37,7 @@ class RSSFeedStoryProvider(StoryProvider):
 
         doc = Document(req.content)
         source = entry["link"].split(".")[1]
-        story = Story(doc.title(), body_html=doc.summary(), byline=source) 
+        story = Story(doc.title(), body_html=doc.summary(), byline=source)
 
         return story
 


### PR DESCRIPTION
This enables optional single-threaded fetching of RSS feeds with `"parallel": false` in the config.

This potentially fixes #53 — separately, the default RSS example config was broken! So this PR also resolves that.

@kwillno — does this fix the issue you were encountering?