### PR TITLE
Deduplicate config files if specified more than once

### DIFF
--- a/goosepaper/multiparser.py
+++ b/goosepaper/multiparser.py
@@ -102,11 +102,11 @@ class MultiParser:
         #  2. Local directory from which goosepaper is called
         #  3. Specified on the command line.
 
-        defaultconfigs = [
+        defaultconfigs = list(set([
             str(pathlib.Path("~").expanduser()) + "/.goosepaper.json",
-            "./goosepaper.json",
+            "goosepaper.json",
             self.args.config,
-        ]
+        ]))
         self.config = {}
         outputcount = 0
         debug_configs = True if self.args.showconfig else None

--- a/goosepaper/util.py
+++ b/goosepaper/util.py
@@ -83,10 +83,9 @@ def construct_story_providers_from_config_dict(config: dict):
         provider_name = provider_config["provider"]
         if provider_name not in StoryProviderConfigNames:
             raise ValueError(f"Provider {provider_name} does not exist.")
-        if provider_config["config"].get("skip"):
+        arguments = provider_config["config"] if "config" in provider_config else {}
+        if arguments.get("skip"):
             continue
         else:
-            stories.append(
-                StoryProviderConfigNames[provider_name](**provider_config["config"])
-            )
+            stories.append(StoryProviderConfigNames[provider_name](**arguments))
     return stories


### PR DESCRIPTION
Previously,

```
goosepaper -c goosepaper.json
```

would cause duplicates of every story. This resolves that. 