### PR TITLE
Gracefully fall back on titles-only for RSS feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+### **Unreleased**
+
+-   Improvements
+    -   RSS stories now "fall back" gracefully on just rendering the title, if the full body cannot be rendered. This is in contrast with the old behavior, in which the story would not be rendered at all.
+
 ### **0.4.0** (January 13 2022)
 
 > Multiple fixes and improvements

--- a/goosepaper/rss.py
+++ b/goosepaper/rss.py
@@ -10,12 +10,16 @@ from .storyprovider import StoryProvider
 
 def parallelizable_request(entry):
     req = requests.get(entry["link"])
+    source = entry["link"].split(".")[1]
     if not req.ok:
-        print(f"Honk! Couldn't get content for {entry['link']}")
-        return None
+        # Just return the headline content:
+        return Story(
+            entry["title"],
+            body_text=entry["description"] + " ⋮",
+            byline=source,
+        )
 
     doc = Document(req.content)
-    source = entry["link"].split(".")[1]
     story = Story(doc.title(), body_html=doc.summary(), byline=source)
 
     return story


### PR DESCRIPTION
If a full page cannot be fetched, fall back on the short description and title only.