### PR TITLE
Add support for multiple styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Improvements
     -   RSS stories now "fall back" gracefully on just rendering the title, if the full body cannot be rendered. This is in contrast with the old behavior, in which the story would not be rendered at all.
     -   RSS, Reddit, and Twitter story providers now support a `since_days_ago` argument in their `config` dictionaries that enables you to specify how many days ago to start the search for stories. Older stories will not be included.
+    -   Add support for multiple styles, using the `"styles" config option. Options are `"Academy"`, `"FifthAvenue"`, and `"Autumn"`. Previous style (before v0.4.0) was `Autumn`.
 
 ### **0.4.0** (January 13 2022)
 

--- a/docs/StyleGallery.md
+++ b/docs/StyleGallery.md
@@ -1,7 +1,7 @@
 # Styles
 
 
- | Autumn | Fifth Avenue | Academy |
+ | Autumn | FifthAvenue | Academy |
 |:------:|:-----------:|:-----:|
 | <img width="683" alt="image" src="https://user-images.githubusercontent.com/693511/149552479-de5bcc0e-78a2-41c9-a77f-0e0dabbe16e6.png"> | <img width="687" alt="image" src="https://user-images.githubusercontent.com/693511/149553007-0b7daee2-b6ef-40d3-99bd-4810b1f08e8c.png"> | <img width="687" alt="image" src="https://user-images.githubusercontent.com/693511/149553983-183247a4-7610-4819-b502-87c2fa14fb45.png"> |
 

--- a/docs/StyleGallery.md
+++ b/docs/StyleGallery.md
@@ -1,0 +1,8 @@
+# Styles
+
+
+ | Autumn | Fifth Avenue | Academy |
+|:------:|:-----------:|:-----:|
+| <img width="683" alt="image" src="https://user-images.githubusercontent.com/693511/149552479-de5bcc0e-78a2-41c9-a77f-0e0dabbe16e6.png"> | <img width="687" alt="image" src="https://user-images.githubusercontent.com/693511/149553007-0b7daee2-b6ef-40d3-99bd-4810b1f08e8c.png"> | <img width="687" alt="image" src="https://user-images.githubusercontent.com/693511/149553983-183247a4-7610-4819-b502-87c2fa14fb45.png"> |
+
+To specify a style, add `"style": "Academy"` to your `goosepaper.json` config file.

--- a/docs/example_library_usage.py
+++ b/docs/example_library_usage.py
@@ -2,11 +2,11 @@ import logging
 from datetime import datetime
 
 from goosepaper.goosepaper import Goosepaper
-from goosepaper.reddit import RedditHeadlineStoryProvider
-from goosepaper.rss import RSSFeedStoryProvider
-from goosepaper.twitter import MultiTwitterStoryProvider
-from goosepaper.weather import WeatherStoryProvider
-from goosepaper.wikipedia import WikipediaCurrentEventsStoryProvider
+from goosepaper.storyprovider.reddit import RedditHeadlineStoryProvider
+from goosepaper.storyprovider.rss import RSSFeedStoryProvider
+from goosepaper.storyprovider.twitter import MultiTwitterStoryProvider
+from goosepaper.storyprovider.weather import WeatherStoryProvider
+from goosepaper.storyprovider.wikipedia import WikipediaCurrentEventsStoryProvider
 from goosepaper.upload import upload
 
 

--- a/goosepaper/__main__.py
+++ b/goosepaper/__main__.py
@@ -21,6 +21,7 @@ def main():
     if not nostory:  # global nostory flag
         story_providers = construct_story_providers_from_config_dict(config)
         font_size = multiparser.argumentOrConfig("font_size", 14)
+        style = multiparser.argumentOrConfig("style", "FifthAvenue")
 
         title = config["title"] if "title" in config else None
         subtitle = config["subtitle"] if "subtitle" in config else None
@@ -33,9 +34,9 @@ def main():
             with open(filename, "w") as fh:
                 fh.write(paper.to_html())
         elif filename.endswith(".pdf"):
-            paper.to_pdf(filename, font_size=font_size)
+            paper.to_pdf(filename, font_size=font_size, style=style)
         elif filename.endswith(".epub"):
-            paper.to_epub(filename, font_size=font_size)
+            paper.to_epub(filename, font_size=font_size, style=style)
         else:
             print(f"Unknown file extension '{filename.split('.')[-1]}'.")
             exit(1)

--- a/goosepaper/multiparser.py
+++ b/goosepaper/multiparser.py
@@ -102,11 +102,15 @@ class MultiParser:
         #  2. Local directory from which goosepaper is called
         #  3. Specified on the command line.
 
-        defaultconfigs = list(set([
-            str(pathlib.Path("~").expanduser()) + "/.goosepaper.json",
-            "goosepaper.json",
-            self.args.config,
-        ]))
+        defaultconfigs = list(
+            set(
+                [
+                    str(pathlib.Path("~").expanduser()) + "/.goosepaper.json",
+                    "goosepaper.json",
+                    self.args.config,
+                ]
+            )
+        )
         self.config = {}
         outputcount = 0
         debug_configs = True if self.args.showconfig else None

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -23,6 +23,7 @@ class AutumnStyle(Style):
             margin-top: 0.5in;
             margin-right: 0.2in;
             margin-left: 0.65in;
+            margin-bottom: 0.2in;
         }
 
         body {
@@ -156,10 +157,11 @@ class FifthAvenueStyle(Style):
             margin-top: 0.5in;
             margin-right: 0.2in;
             margin-left: 0.65in;
+            margin-bottom: 0.2in;
         }
 
         body {
-            font-family: "Source Serif Pro";
+            font-family: "Open Sans";
         }
 
         .header {
@@ -267,6 +269,124 @@ class FifthAvenueStyle(Style):
 
         .row {
             column-count: 2;
+        }
+
+        """
+        )
+
+
+class AcademyStyle(Style):
+    def get_stylesheets(self) -> list:
+        return []
+
+    def get_name(self):
+        return "Academy"
+
+    def get_css(self, font_size: int = 14):
+        return (
+            """
+        @page {
+            margin-top: 0.5in;
+            margin-right: 0.2in;
+            margin-left: 0.65in;
+            margin-bottom: 0.2in;
+        }
+
+        body {
+            font-family: "Times New Roman";
+        }
+
+        .header {
+            padding: 1em;
+            height: 10em;
+        }
+
+        .header div {
+            float: left;
+            display: block;
+        }
+
+        .header .ear {
+            float: right;
+        }
+
+        .stories {
+            font-size: """
+            + str(font_size)
+            + """pt;
+        }
+
+        .ear article {
+            border: 3px groove black;
+            padding: 1em;
+            margin: 1em;
+            font-size: 11pt;
+        }
+        .ear article h1 {
+            font-family: "Times New Roman";
+            font-size: 10pt;
+            font-weight: normal;
+        }
+
+        article {
+            text-align: left;
+            line-height: 1.4em;
+        }
+
+        article>h1 {
+            font-family: "Times New Roman";
+            font-weight: 400;
+            font-size: 23pt;
+            text-indent: 0;
+            margin-bottom: 0.25em;
+            line-height: 1.2em;
+            text-align: left;
+        }
+        article>h1.priority-low {
+            font-family: "Times New Roman";
+            font-size: 18pt;
+            font-weight: 400;
+            text-indent: 0;
+            margin-bottom: 0.15em;
+        }
+
+        article>h4.byline {
+            font-family: "Times New Roman";
+            font-size: """
+            + str(font_size)
+            + """pt;
+            font-weight: 400;
+            text-indent: 0;
+        }
+
+        article>h3 {
+            font-family: "Times New Roman";
+            font-weight: 400;
+            font-size: 18pt;
+            text-indent: 0;
+        }
+
+        section>h1,
+        section>h2,
+        section>h3,
+        section>h4,
+        section>h5 {
+            border-left: 5px solid #dedede;
+            padding-left: 1em;
+        }
+
+        figure {
+            border: 1px solid black;
+            text-indent: 0;
+            width: auto;
+        }
+
+        .stories article.story img {
+            width: 100%;
+        }
+
+        figure>span {
+            font-size: 0;
         }
 
         """

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -13,6 +13,9 @@ class AutumnStyle(Style):
             "https://fonts.googleapis.com/css?family=Playfair+Display",
         ]
 
+    def get_name(self):
+        return "Autumn"
+
     def get_css(self, font_size: int = 14):
         return (
             """
@@ -101,6 +104,139 @@ class AutumnStyle(Style):
 
         article>h3 {
             font-family: "Oswald";
+            font-weight: 400;
+            font-size: 18pt;
+            text-indent: 0;
+        }
+
+        section>h1,
+        section>h2,
+        section>h3,
+        section>h4,
+        section>h5 {
+            border-left: 5px solid #dedede;
+            padding-left: 1em;
+        }
+
+        figure {
+            border: 1px solid black;
+            text-indent: 0;
+            width: auto;
+        }
+
+        .stories article.story img {
+            width: 100%;
+        }
+
+        figure>span {
+            font-size: 0;
+        }
+
+        .row {
+            column-count: 2;
+        }
+
+        """
+        )
+
+
+class FifthAvenueStyle(Style):
+    def get_stylesheets(self) -> list:
+        return [
+            "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap",
+        ]
+
+    def get_name(self):
+        return "FifthAvenue"
+
+    def get_css(self, font_size: int = 14):
+        return (
+            """
+        @page {
+            margin-top: 0.5in;
+            margin-right: 0.2in;
+            margin-left: 0.65in;
+        }
+
+        body {
+            font-family: "Source Serif Pro";
+        }
+
+        .header {
+            padding: 1em;
+            height: 10em;
+        }
+
+        .header div {
+            float: left;
+            display: block;
+        }
+
+        .header .ear {
+            float: right;
+        }
+
+        ul, li, ol {
+            margin-left: 0; padding-left: 0.15em;
+        }
+
+        .stories {
+            font-size: """
+            + str(font_size)
+            + """pt;
+        }
+
+        .ear article {
+            border: 1px groove black;
+            padding: 1em;
+            margin: 1em;
+            font-size: 11pt;
+        }
+        .ear article h1 {
+            font-family: "Source Serif Pro";
+            font-size: 10pt;
+            font-weight: normal;
+        }
+
+        article {
+            text-align: justify;
+            line-height: 1.3em;
+        }
+
+        .longform {
+            page-break-after: always;
+        }
+
+        article>h1 {
+            font-family: "Source Serif Pro";
+            font-weight: 400;
+            font-size: 23pt;
+            text-indent: 0;
+            margin-bottom: 0.25em;
+            line-height: 1.2em;
+            text-align: left;
+        }
+        article>h1.priority-low {
+            font-family: "Open Sans";
+            font-size: 18pt;
+            font-weight: 400;
+            text-indent: 0;
+            border-bottom: 1px solid #dedede;
+            margin-bottom: 0.15em;
+        }
+
+        article>h4.byline {
+            font-family: "Open Sans";
+            font-size: """
+            + str(font_size)
+            + """pt;
+            font-weight: 400;
+            text-indent: 0;
+            border-bottom: 1px solid #dedede;
+        }
+
+        article>h3 {
+            font-family: "Open Sans";
             font-weight: 400;
             font-size: 18pt;
             text-indent: 0;


### PR DESCRIPTION

 | Autumn | FifthAvenue | Academy |
|:------:|:-----------:|:-----:|
| <img width="683" alt="image" src="https://user-images.githubusercontent.com/693511/149552479-de5bcc0e-78a2-41c9-a77f-0e0dabbe16e6.png"> | <img width="687" alt="image" src="https://user-images.githubusercontent.com/693511/149553007-0b7daee2-b6ef-40d3-99bd-4810b1f08e8c.png"> | <img width="687" alt="image" src="https://user-images.githubusercontent.com/693511/149553983-183247a4-7610-4819-b502-87c2fa14fb45.png"> |

To specify a style, add `"style": "Academy"` to your `goosepaper.json` config file.