### PR TITLE
Styles-as-plugin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ docs
 Dockerfile
 *.pdf
 *.json
+*.yml

--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Check out [this example PDF](https://github.com/j6k4m8/goosepaper/blob/master/do
 -   [RSS Feeds](https://github.com/j6k4m8/goosepaper/blob/master/goosepaper/storyprovider/rss.py)
 -   [Reddit Subreddits](https://github.com/j6k4m8/goosepaper/blob/master/goosepaper/storyprovider/reddit.py)
 
+## Edit your own styles!
+
+The pdf styles are controlled by css. You may find three available styles in `styles` folder: `FifthAvenue`, `Autumn` and `Academy`. Choose your style by adding one line in your `config.json` file:
+
+```
+"style": "<style name>"
+```
+
+Adding a custom style is simple, by creating a new folder in styles folder with the name your prefer (e.g. `my-custom-style`), and put your css file in this folder. Then, just change the <style name> in your `config.json` to this new folder name (i.e. "style": "my-custom-style").
+
+If you want to use online stylesheets, you may create a `stylesheet.txt` file. Each line in `stylesheets.txt` contains a link to the stylesheet. 
+
 # More Questions, Infrequently Asked
 
 ### yes but pardon me — i haven't a remarkable tablet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: "2.1"
+services:
+  goosepaper:
+    image: goosepaper 
+    container_name: mygoosepaper
+    volumes:
+      - /absolute/path/to/goosepaper.json:/app/goosepaper.json
+      - /absolute/path/to/output/folder/:/output #(optional) config.json： "output":"/output/Goose.pdf"
+      - /absolute/path/to/customstyle:/app/styles/customstyle #(optional) config.json: "style":"customstyle"
+    command: goosepaper

--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -145,7 +145,7 @@ class Goosepaper:
     def to_pdf(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str] = 'FifthAvenue',
+        style: Union[str] = '',
         font_size: int = 14,
     ) -> Optional[str]:
         """

--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import List, Optional, Type, Union
 import datetime
 import io
@@ -169,7 +170,10 @@ class Goosepaper:
         style_obj = _get_style(style)
         html = self.to_html()
         h = HTML(string=html)
-        c = CSS(string=style_obj.get_css(font_size),font_config=font_config)
+        base_url = str(pathlib.Path.cwd())
+        c = CSS(string=style_obj.get_css(font_size),
+            font_config=font_config,
+            base_url=base_url)
         # Check if the file is a filepath (str):
         if isinstance(filename, str):
             h.write_pdf(

--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -6,18 +6,14 @@ from uuid import uuid4
 
 from goosepaper.story import Story
 
-from .styles import Style, AutumnStyle, FifthAvenueStyle, AcademyStyle
+from .styles import Style
 from .util import PlacementPreference
 from .storyprovider.storyprovider import StoryProvider
 
 
 def _get_style(style):
     if isinstance(style, str):
-        style_obj = {
-            "FifthAvenue": FifthAvenueStyle,
-            "Autumn": AutumnStyle,
-            "Academy": AcademyStyle,
-        }.get(style, FifthAvenueStyle)()
+        style_obj = Style(style)
     else:
         try:
             style_obj = style()
@@ -148,7 +144,7 @@ class Goosepaper:
     def to_pdf(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str, Type[Style]] = FifthAvenueStyle,
+        style: Union[str] = 'FifthAvenue',
         font_size: int = 14,
     ) -> Optional[str]:
         """
@@ -167,16 +163,19 @@ class Goosepaper:
 
         """
         from weasyprint import HTML, CSS
+        from weasyprint.text.fonts import FontConfiguration
 
+        font_config = FontConfiguration()
         style_obj = _get_style(style)
         html = self.to_html()
         h = HTML(string=html)
-        c = CSS(string=style_obj.get_css(font_size))
+        c = CSS(string=style_obj.get_css(font_size),font_config=font_config)
         # Check if the file is a filepath (str):
         if isinstance(filename, str):
             h.write_pdf(
                 filename,
                 stylesheets=[c, *style_obj.get_stylesheets()],
+                font_config=font_config
             )
             return filename
         elif isinstance(filename, io.BytesIO):
@@ -195,7 +194,7 @@ class Goosepaper:
     def to_epub(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str, Type[Style]] = FifthAvenueStyle,
+        style: Union[str, Type[Style]] = 'FifthAvenue',
         font_size: int = 14,
     ) -> Optional[str]:
         """

--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -198,7 +198,7 @@ class Goosepaper:
     def to_epub(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str, Type[Style]] = 'FifthAvenue',
+        style: Union[str, Type[Style]] = '',
         font_size: int = 14,
     ) -> Optional[str]:
         """

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -31,17 +31,135 @@ class Style:
 
     def read_style(self, path):
         path = pathlib.Path("./styles/") / path
-        self.__stylesheets__ = read_stylesheets(path)
-        self.__css__ = read_css(path)
+        if not hasattr(self, '__css__'):
+            self.__stylesheets__ = read_stylesheets(path)
+            self.__css__ = read_css(path)
+
+    def read_default_style(self): #code copied from FifthAvenueStyle
+        if not hasattr(self, '__css__'):
+            self.__stylesheets__ = [
+            "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap",
+        ]
+            self.__css__ = """
+                @page {
+                    margin-top: 0.5in;
+                    margin-right: 0.2in;
+                    margin-left: 0.65in;
+                    margin-bottom: 0.2in;
+                }
+
+                body {
+                    font-family: "Open Sans";
+                }
+
+                .header {
+                    padding: 1em;
+                    height: 10em;
+                }
+
+                .header div {
+                    float: left;
+                    display: block;
+                }
+
+                .header .ear {
+                    float: right;
+                }
+
+                ul, li, ol {
+                    margin-left: 0; padding-left: 0.15em;
+                }
+
+                .stories {
+                    font-size: 14pt;
+                }
+
+                .ear article {
+                    border: 1px groove black;
+                    padding: 1em;
+                    margin: 1em;
+                    font-size: 11pt;
+                }
+                .ear article h1 {
+                    font-family: "Source Serif Pro";
+                    font-size: 10pt;
+                    font-weight: normal;
+                }
+
+                article {
+                    text-align: justify;
+                    line-height: 1.3em;
+                }
+
+                .longform {
+                    page-break-after: always;
+                }
+
+                article>h1 {
+                    font-family: "Source Serif Pro";
+                    font-weight: 400;
+                    font-size: 23pt;
+                    text-indent: 0;
+                    margin-bottom: 0.25em;
+                    line-height: 1.2em;
+                    text-align: left;
+                }
+                article>h1.priority-low {
+                    font-family: "Open Sans";
+                    font-size: 18pt;
+                    font-weight: 400;
+                    text-indent: 0;
+                    border-bottom: 1px solid #dedede;
+                    margin-bottom: 0.15em;
+                }
+
+                article>h4.byline {
+                    font-family: "Open Sans";
+                    font-size: 14pt;
+                    font-weight: 400;
+                    text-indent: 0;
+                    border-bottom: 1px solid #dedede;
+                }
+
+                article>h3 {
+                    font-family: "Open Sans";
+                    font-weight: 400;
+                    font-size: 18pt;
+                    text-indent: 0;
+                }
+
+                section>h1,
+                section>h2,
+                section>h3,
+                section>h4,
+                section>h5 {
+                    border-left: 5px solid #dedede;
+                    padding-left: 1em;
+                }
+
+                figure {
+                    border: 1px solid black;
+                    text-indent: 0;
+                    width: auto;
+                }
+
+                .stories article.story img {
+                    width: 100%;
+                }
+
+                figure>span {
+                    font-size: 0;
+                }
+
+                .row {
+                    column-count: 2;
+                }"""
 
     def __init__(self, path = ''):
-        try:
-            self.read_style(path)
-        except FileNotFoundError:
-            if path:
-                print(f"Oops! {path} style not found. Use default style.")
-            else:
-                self.read_style('FifthAvenue')
+        if path:
+            try:
+                self.read_style(path)
+            except FileNotFoundError:
+                print(f"Oops! {path} style not found or broken. Use default style.")
+        self.read_default_style() # if style not found
         return
-
-

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -1,393 +1,47 @@
-class Style:
-    def get_stylesheets(self) -> list:
-        ...
-
-    def get_css(self, font_size: int = 14):
-        ...
+import pathlib
 
 
-class AutumnStyle(Style):
-    def get_stylesheets(self) -> list:
-        return [
-            "https://fonts.googleapis.com/css?family=Oswald",
-            "https://fonts.googleapis.com/css?family=Playfair+Display",
-        ]
-
-    def get_name(self):
-        return "Autumn"
-
-    def get_css(self, font_size: int = 14):
-        return (
-            """
-        @page {
-            margin-top: 0.5in;
-            margin-right: 0.2in;
-            margin-left: 0.65in;
-            margin-bottom: 0.2in;
-        }
-
-        body {
-            font-family: "Playfair Display";
-        }
-
-        .header {
-            padding: 1em;
-            height: 10em;
-        }
-
-        .header div {
-            float: left;
-            display: block;
-        }
-
-        .header .ear {
-            float: right;
-        }
-
-        ul, li, ol {
-            margin-left: 0; padding-left: 0.15em;
-        }
-
-        .stories {
-            font-size: """
-            + str(font_size)
-            + """pt;
-        }
-
-        .ear article {
-            border: 1px groove black;
-            padding: 1em;
-            margin: 1em;
-            font-size: 11pt;
-        }
-        .ear article h1 {
-            font-family: "Playfair Display";
-            font-size: 10pt;
-            font-weight: normal;
-        }
-
-        article {
-            text-align: justify;
-            line-height: 1.25em;
-        }
-
-        .longform {
-            page-break-after: always;
-        }
-
-        article>h1 {
-            font-family: "Oswald";
-            font-weight: 400;
-            font-size: 23pt;
-            text-indent: 0;
-            margin-bottom: 0.25em;
-            line-height: 1.2em;
-            text-align: left;
-        }
-        article>h1.priority-low {
-            font-family: "Oswald";
-            font-size: 18pt;
-            font-weight: 400;
-            text-indent: 0;
-            border-bottom: 1px solid #dedede;
-            margin-bottom: 0.15em;
-        }
-
-        article>h4.byline {
-            font-family: "Oswald";
-            font-size: """
-            + str(font_size)
-            + """pt;
-            font-weight: 400;
-            text-indent: 0;
-            border-bottom: 1px solid #dedede;
-        }
-
-        article>h3 {
-            font-family: "Oswald";
-            font-weight: 400;
-            font-size: 18pt;
-            text-indent: 0;
-        }
-
-        section>h1,
-        section>h2,
-        section>h3,
-        section>h4,
-        section>h5 {
-            border-left: 5px solid #dedede;
-            padding-left: 1em;
-        }
-
-        figure {
-            border: 1px solid black;
-            text-indent: 0;
-            width: auto;
-        }
-
-        .stories article.story img {
-            width: 100%;
-        }
-
-        figure>span {
-            font-size: 0;
-        }
-
-        .row {
-            column-count: 2;
-        }
-
-        """
-        )
-
-
-class FifthAvenueStyle(Style):
-    def get_stylesheets(self) -> list:
-        return [
-            "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap",
-        ]
-
-    def get_name(self):
-        return "FifthAvenue"
-
-    def get_css(self, font_size: int = 14):
-        return (
-            """
-        @page {
-            margin-top: 0.5in;
-            margin-right: 0.2in;
-            margin-left: 0.65in;
-            margin-bottom: 0.2in;
-        }
-
-        body {
-            font-family: "Open Sans";
-        }
-
-        .header {
-            padding: 1em;
-            height: 10em;
-        }
-
-        .header div {
-            float: left;
-            display: block;
-        }
-
-        .header .ear {
-            float: right;
-        }
-
-        ul, li, ol {
-            margin-left: 0; padding-left: 0.15em;
-        }
-
-        .stories {
-            font-size: """
-            + str(font_size)
-            + """pt;
-        }
-
-        .ear article {
-            border: 1px groove black;
-            padding: 1em;
-            margin: 1em;
-            font-size: 11pt;
-        }
-        .ear article h1 {
-            font-family: "Source Serif Pro";
-            font-size: 10pt;
-            font-weight: normal;
-        }
-
-        article {
-            text-align: justify;
-            line-height: 1.3em;
-        }
-
-        .longform {
-            page-break-after: always;
-        }
-
-        article>h1 {
-            font-family: "Source Serif Pro";
-            font-weight: 400;
-            font-size: 23pt;
-            text-indent: 0;
-            margin-bottom: 0.25em;
-            line-height: 1.2em;
-            text-align: left;
-        }
-        article>h1.priority-low {
-            font-family: "Open Sans";
-            font-size: 18pt;
-            font-weight: 400;
-            text-indent: 0;
-            border-bottom: 1px solid #dedede;
-            margin-bottom: 0.15em;
-        }
-
-        article>h4.byline {
-            font-family: "Open Sans";
-            font-size: """
-            + str(font_size)
-            + """pt;
-            font-weight: 400;
-            text-indent: 0;
-            border-bottom: 1px solid #dedede;
-        }
-
-        article>h3 {
-            font-family: "Open Sans";
-            font-weight: 400;
-            font-size: 18pt;
-            text-indent: 0;
-        }
-
-        section>h1,
-        section>h2,
-        section>h3,
-        section>h4,
-        section>h5 {
-            border-left: 5px solid #dedede;
-            padding-left: 1em;
-        }
-
-        figure {
-            border: 1px solid black;
-            text-indent: 0;
-            width: auto;
-        }
-
-        .stories article.story img {
-            width: 100%;
-        }
-
-        figure>span {
-            font-size: 0;
-        }
-
-        .row {
-            column-count: 2;
-        }
-
-        """
-        )
-
-
-class AcademyStyle(Style):
-    def get_stylesheets(self) -> list:
+def read_stylesheets(path: pathlib.Path) -> list:
+    if (path/"stylesheets.txt").is_file():
+        return (path / "stylesheets.txt").read_text()\
+            .strip("\n").split("\n")
+    else:
         return []
 
-    def get_name(self):
-        return "Academy"
+def read_css(path: pathlib.Path):
+    return (path / "stylesheet.css") \
+        .read_text()
 
-    def get_css(self, font_size: int = 14):
-        return (
-            """
-        @page {
-            margin-top: 0.5in;
-            margin-right: 0.2in;
-            margin-left: 0.65in;
-            margin-bottom: 0.2in;
-        }
+class Style:
+    def get_stylesheets(self) -> list:
+        return getattr(self,"__stylesheets__","")
 
-        body {
-            font-family: "Times New Roman";
-        }
-
-        .header {
-            padding: 1em;
-            height: 10em;
-        }
-
-        .header div {
-            float: left;
-            display: block;
-        }
-
-        .header .ear {
-            float: right;
-        }
-
-        .stories {
-            font-size: """
-            + str(font_size)
-            + """pt;
-        }
-
-        .ear article {
-            border: 3px groove black;
-            padding: 1em;
-            margin: 1em;
-            font-size: 11pt;
-        }
-        .ear article h1 {
-            font-family: "Times New Roman";
-            font-size: 10pt;
-            font-weight: normal;
-        }
-
-        article {
-            text-align: left;
-            line-height: 1.4em;
-        }
-
-        article>h1 {
-            font-family: "Times New Roman";
-            font-weight: 400;
-            font-size: 23pt;
-            text-indent: 0;
-            margin-bottom: 0.25em;
-            line-height: 1.2em;
-            text-align: left;
-        }
-        article>h1.priority-low {
-            font-family: "Times New Roman";
-            font-size: 18pt;
-            font-weight: 400;
-            text-indent: 0;
-            margin-bottom: 0.15em;
-        }
-
-        article>h4.byline {
-            font-family: "Times New Roman";
-            font-size: """
-            + str(font_size)
-            + """pt;
-            font-weight: 400;
-            text-indent: 0;
-        }
-
-        article>h3 {
-            font-family: "Times New Roman";
-            font-weight: 400;
-            font-size: 18pt;
-            text-indent: 0;
-        }
-
-        section>h1,
-        section>h2,
-        section>h3,
-        section>h4,
-        section>h5 {
-            border-left: 5px solid #dedede;
-            padding-left: 1em;
-        }
-
-        figure {
-            border: 1px solid black;
-            text-indent: 0;
-            width: auto;
-        }
-
-        .stories article.story img {
-            width: 100%;
-        }
-
-        figure>span {
-            font-size: 0;
-        }
-
+    def get_css(self, font_size: int = None):
+        font_size=str(font_size)
+        if font_size:
+            self.__css__+= f"""
+        .stories {{
+            font-size: {font_size}pt !important; 
+        }}
+        article>h4.byline {{
+            font-size: {font_size}pt !important; 
+        }}
         """
-        )
+        return getattr(self, "__css__", "")
+
+    def read_style(self, path):
+        path = pathlib.Path("./styles/") / path
+        self.__stylesheets__ = read_stylesheets(path)
+        self.__css__ = read_css(path)
+
+    def __init__(self, path = ''):
+        try:
+            self.read_style(path)
+        except FileNotFoundError:
+            if path:
+                print(f"Oops! {path} style not found. Use default style.")
+            else:
+                self.read_style('FifthAvenue')
+        return
+
+

--- a/goosepaper/util.py
+++ b/goosepaper/util.py
@@ -12,6 +12,7 @@ def htmlize(text: Union[str, List[str]]) -> str:
     #   * Escaping
     #   * Paragraph delims
     #   * Remove illegal elements
+    text = text.replace("<br />", "")
     if isinstance(text, list):
         return "".join([f"<p>{line}</p>" for line in text])
     return f"<p>{text}</p>"

--- a/styles/Academy/stylesheet.css
+++ b/styles/Academy/stylesheet.css
@@ -1,0 +1,85 @@
+@page {
+    margin-top: 0.5in;
+    margin-right: 0.2in;
+    margin-left: 0.65in;
+    margin-bottom: 0.2in;
+}
+body {
+    font-family: "Times New Roman";
+}
+.header {
+    padding: 1em;
+    height: 10em;
+}
+.header div {
+    float: left;
+    display: block;
+}
+.header .ear {
+    float: right;
+}
+.stories {
+    font-size: 14pt;
+}
+.ear article {
+    border: 3px groove black;
+    padding: 1em;
+    margin: 1em;
+    font-size: 11pt;
+}
+.ear article h1 {
+    font-family: "Times New Roman";
+    font-size: 10pt;
+    font-weight: normal;
+}
+article {
+    text-align: left;
+    line-height: 1.4em;
+}
+article>h1 {
+    font-family: "Times New Roman";
+    font-weight: 400;
+    font-size: 23pt;
+    text-indent: 0;
+    margin-bottom: 0.25em;
+    line-height: 1.2em;
+    text-align: left;
+}
+article>h1.priority-low {
+    font-family: "Times New Roman";
+    font-size: 18pt;
+    font-weight: 400;
+    text-indent: 0;
+    margin-bottom: 0.15em;
+}
+article>h4.byline {
+    font-family: "Times New Roman";
+    font-size: 14pt;
+    font-weight: 400;
+    text-indent: 0;
+}
+article>h3 {
+    font-family: "Times New Roman";
+    font-weight: 400;
+    font-size: 18pt;
+    text-indent: 0;
+}
+section>h1,
+section>h2,
+section>h3,
+section>h4,
+section>h5 {
+    border-left: 5px solid #dedede;
+    padding-left: 1em;
+}
+figure {
+    border: 1px solid black;
+    text-indent: 0;
+    width: auto;
+}
+.stories article.story img {
+    width: 100%;
+}
+figure>span {
+    font-size: 0;
+}

--- a/styles/Autumn/stylesheet.css
+++ b/styles/Autumn/stylesheet.css
@@ -1,0 +1,96 @@
+@page {
+    margin-top: 0.5in;
+    margin-right: 0.2in;
+    margin-left: 0.65in;
+    margin-bottom: 0.2in;
+}
+body {
+    font-family: "Playfair Display";
+}
+.header {
+    padding: 1em;
+    height: 10em;
+}
+.header div {
+    float: left;
+    display: block;
+}
+.header .ear {
+    float: right;
+}
+ul, li, ol {
+    margin-left: 0; padding-left: 0.15em;
+}
+.stories {
+    font-size: 14pt;
+}
+.ear article {
+    border: 1px groove black;
+    padding: 1em;
+    margin: 1em;
+    font-size: 11pt;
+}
+.ear article h1 {
+    font-family: "Playfair Display";
+    font-size: 10pt;
+    font-weight: normal;
+}
+article {
+    text-align: justify;
+    line-height: 1.25em;
+}
+.longform {
+    page-break-after: always;
+}
+article>h1 {
+    font-family: "Oswald";
+    font-weight: 400;
+    font-size: 23pt;
+    text-indent: 0;
+    margin-bottom: 0.25em;
+    line-height: 1.2em;
+    text-align: left;
+}
+article>h1.priority-low {
+    font-family: "Oswald";
+    font-size: 18pt;
+    font-weight: 400;
+    text-indent: 0;
+    border-bottom: 1px solid #dedede;
+    margin-bottom: 0.15em;
+}
+article>h4.byline {
+    font-family: "Oswald";
+    font-size: 14pt;
+    font-weight: 400;
+    text-indent: 0;
+    border-bottom: 1px solid #dedede;
+}
+article>h3 {
+    font-family: "Oswald";
+    font-weight: 400;
+    font-size: 18pt;
+    text-indent: 0;
+}
+section>h1,
+section>h2,
+section>h3,
+section>h4,
+section>h5 {
+    border-left: 5px solid #dedede;
+    padding-left: 1em;
+}
+figure {
+    border: 1px solid black;
+    text-indent: 0;
+    width: auto;
+}
+.stories article.story img {
+    width: 100%;
+}
+figure>span {
+    font-size: 0;
+}
+.row {
+    column-count: 2;
+}

--- a/styles/Autumn/stylesheets.txt
+++ b/styles/Autumn/stylesheets.txt
@@ -1,0 +1,2 @@
+https://fonts.googleapis.com/css?family=Oswald
+https://fonts.googleapis.com/css?family=Playfair+Display

--- a/styles/FifthAvenue/stylesheet.css
+++ b/styles/FifthAvenue/stylesheet.css
@@ -1,0 +1,96 @@
+@page {
+    margin-top: 0.5in;
+    margin-right: 0.2in;
+    margin-left: 0.65in;
+    margin-bottom: 0.2in;
+}
+body {
+    font-family: "Open Sans";
+}
+.header {
+    padding: 1em;
+    height: 10em;
+}
+.header div {
+    float: left;
+    display: block;
+}
+.header .ear {
+    float: right;
+}
+ul, li, ol {
+    margin-left: 0; padding-left: 0.15em;
+}
+.stories {
+    font-size: 14pt;
+}
+.ear article {
+    border: 1px groove black;
+    padding: 1em;
+    margin: 1em;
+    font-size: 11pt;
+}
+.ear article h1 {
+    font-family: "Source Serif Pro";
+    font-size: 10pt;
+    font-weight: normal;
+}
+article {
+    text-align: justify;
+    line-height: 1.3em;
+}
+.longform {
+    page-break-after: always;
+}
+article>h1 {
+    font-family: "Source Serif Pro";
+    font-weight: 400;
+    font-size: 23pt;
+    text-indent: 0;
+    margin-bottom: 0.25em;
+    line-height: 1.2em;
+    text-align: left;
+}
+article>h1.priority-low {
+    font-family: "Open Sans";
+    font-size: 18pt;
+    font-weight: 400;
+    text-indent: 0;
+    border-bottom: 1px solid #dedede;
+    margin-bottom: 0.15em;
+}
+article>h4.byline {
+    font-family: "Open Sans";
+    font-size: 14pt;
+    font-weight: 400;
+    text-indent: 0;
+    border-bottom: 1px solid #dedede;
+}
+article>h3 {
+    font-family: "Open Sans";
+    font-weight: 400;
+    font-size: 18pt;
+    text-indent: 0;
+}
+section>h1,
+section>h2,
+section>h3,
+section>h4,
+section>h5 {
+    border-left: 5px solid #dedede;
+    padding-left: 1em;
+}
+figure {
+    border: 1px solid black;
+    text-indent: 0;
+    width: auto;
+}
+.stories article.story img {
+    width: 100%;
+}
+figure>span {
+    font-size: 0;
+}
+.row {
+    column-count: 2;
+}

--- a/styles/FifthAvenue/stylesheets.txt
+++ b/styles/FifthAvenue/stylesheets.txt
@@ -1,0 +1,1 @@
+https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap


### PR DESCRIPTION
The styles were hard-coded in the package; reading them from a styles folder will make goosepaper much easier to customize.

These codes basically do one thing: look for a user-defined style in styles folder, and read it on-the-fly. It keeps one hard-coded style (originally FifthAvenue; now it will only be used when no /wrong style is configured). 