### PR TITLE
Styles as plugin

### DIFF
--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -1,3 +1,4 @@
+import pathlib
 from typing import List, Optional, Type, Union
 import datetime
 import io
@@ -169,7 +170,10 @@ class Goosepaper:
         style_obj = _get_style(style)
         html = self.to_html()
         h = HTML(string=html)
-        c = CSS(string=style_obj.get_css(font_size),font_config=font_config)
+        base_url = str(pathlib.Path.cwd())
+        c = CSS(string=style_obj.get_css(font_size),
+            font_config=font_config,
+            base_url=base_url)
         # Check if the file is a filepath (str):
         if isinstance(filename, str):
             h.write_pdf(

--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -144,7 +144,7 @@ class Goosepaper:
     def to_pdf(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str] = 'FifthAvenue',
+        style: Union[str] = '',
         font_size: int = 14,
     ) -> Optional[str]:
         """
@@ -194,7 +194,7 @@ class Goosepaper:
     def to_epub(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str, Type[Style]] = 'FifthAvenue',
+        style: Union[str, Type[Style]] = '',
         font_size: int = 14,
     ) -> Optional[str]:
         """

--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -145,7 +145,7 @@ class Goosepaper:
     def to_pdf(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str] = '',
+        style: Union[str] = "",
         font_size: int = 14,
     ) -> Optional[str]:
         """
@@ -171,15 +171,17 @@ class Goosepaper:
         html = self.to_html()
         h = HTML(string=html)
         base_url = str(pathlib.Path.cwd())
-        c = CSS(string=style_obj.get_css(font_size),
+        c = CSS(
+            string=style_obj.get_css(font_size),
             font_config=font_config,
-            base_url=base_url)
+            base_url=base_url,
+        )
         # Check if the file is a filepath (str):
         if isinstance(filename, str):
             h.write_pdf(
                 filename,
                 stylesheets=[c, *style_obj.get_stylesheets()],
-                font_config=font_config
+                font_config=font_config,
             )
             return filename
         elif isinstance(filename, io.BytesIO):
@@ -198,7 +200,7 @@ class Goosepaper:
     def to_epub(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str, Type[Style]] = '',
+        style: Union[str, Type[Style]] = "",
         font_size: int = 14,
     ) -> Optional[str]:
         """

--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -6,18 +6,14 @@ from uuid import uuid4
 
 from goosepaper.story import Story
 
-from .styles import Style, AutumnStyle, FifthAvenueStyle, AcademyStyle
+from .styles import Style
 from .util import PlacementPreference
 from .storyprovider.storyprovider import StoryProvider
 
 
 def _get_style(style):
     if isinstance(style, str):
-        style_obj = {
-            "FifthAvenue": FifthAvenueStyle,
-            "Autumn": AutumnStyle,
-            "Academy": AcademyStyle,
-        }.get(style, FifthAvenueStyle)()
+        style_obj = Style(style)
     else:
         try:
             style_obj = style()
@@ -148,7 +144,7 @@ class Goosepaper:
     def to_pdf(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str, Type[Style]] = FifthAvenueStyle,
+        style: Union[str] = 'FifthAvenue',
         font_size: int = 14,
     ) -> Optional[str]:
         """
@@ -167,16 +163,19 @@ class Goosepaper:
 
         """
         from weasyprint import HTML, CSS
+        from weasyprint.text.fonts import FontConfiguration
 
+        font_config = FontConfiguration()
         style_obj = _get_style(style)
         html = self.to_html()
         h = HTML(string=html)
-        c = CSS(string=style_obj.get_css(font_size))
+        c = CSS(string=style_obj.get_css(font_size),font_config=font_config)
         # Check if the file is a filepath (str):
         if isinstance(filename, str):
             h.write_pdf(
                 filename,
                 stylesheets=[c, *style_obj.get_stylesheets()],
+                font_config=font_config
             )
             return filename
         elif isinstance(filename, io.BytesIO):
@@ -195,7 +194,7 @@ class Goosepaper:
     def to_epub(
         self,
         filename: Union[str, io.BytesIO],
-        style: Union[str, Type[Style]] = FifthAvenueStyle,
+        style: Union[str, Type[Style]] = 'FifthAvenue',
         font_size: int = 14,
     ) -> Optional[str]:
         """

--- a/goosepaper/storyprovider/__init__.py
+++ b/goosepaper/storyprovider/__init__.py
@@ -1,1 +1,1 @@
-from .storyprovider import StoryProvider # noqa
+from .storyprovider import StoryProvider  # noqa

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -31,17 +31,135 @@ class Style:
 
     def read_style(self, path):
         path = pathlib.Path("./styles/") / path
-        self.__stylesheets__ = read_stylesheets(path)
-        self.__css__ = read_css(path)
+        if not hasattr(self, '__css__'):
+            self.__stylesheets__ = read_stylesheets(path)
+            self.__css__ = read_css(path)
+
+    def read_default_style(self): #code copied from FifthAvenueStyle
+        if not hasattr(self, '__css__'):
+            self.__stylesheets__ = [
+            "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap",
+        ]
+            self.__css__ = """
+                @page {
+                    margin-top: 0.5in;
+                    margin-right: 0.2in;
+                    margin-left: 0.65in;
+                    margin-bottom: 0.2in;
+                }
+
+                body {
+                    font-family: "Open Sans";
+                }
+
+                .header {
+                    padding: 1em;
+                    height: 10em;
+                }
+
+                .header div {
+                    float: left;
+                    display: block;
+                }
+
+                .header .ear {
+                    float: right;
+                }
+
+                ul, li, ol {
+                    margin-left: 0; padding-left: 0.15em;
+                }
+
+                .stories {
+                    font-size: 14pt;
+                }
+
+                .ear article {
+                    border: 1px groove black;
+                    padding: 1em;
+                    margin: 1em;
+                    font-size: 11pt;
+                }
+                .ear article h1 {
+                    font-family: "Source Serif Pro";
+                    font-size: 10pt;
+                    font-weight: normal;
+                }
+
+                article {
+                    text-align: justify;
+                    line-height: 1.3em;
+                }
+
+                .longform {
+                    page-break-after: always;
+                }
+
+                article>h1 {
+                    font-family: "Source Serif Pro";
+                    font-weight: 400;
+                    font-size: 23pt;
+                    text-indent: 0;
+                    margin-bottom: 0.25em;
+                    line-height: 1.2em;
+                    text-align: left;
+                }
+                article>h1.priority-low {
+                    font-family: "Open Sans";
+                    font-size: 18pt;
+                    font-weight: 400;
+                    text-indent: 0;
+                    border-bottom: 1px solid #dedede;
+                    margin-bottom: 0.15em;
+                }
+
+                article>h4.byline {
+                    font-family: "Open Sans";
+                    font-size: 14pt;
+                    font-weight: 400;
+                    text-indent: 0;
+                    border-bottom: 1px solid #dedede;
+                }
+
+                article>h3 {
+                    font-family: "Open Sans";
+                    font-weight: 400;
+                    font-size: 18pt;
+                    text-indent: 0;
+                }
+
+                section>h1,
+                section>h2,
+                section>h3,
+                section>h4,
+                section>h5 {
+                    border-left: 5px solid #dedede;
+                    padding-left: 1em;
+                }
+
+                figure {
+                    border: 1px solid black;
+                    text-indent: 0;
+                    width: auto;
+                }
+
+                .stories article.story img {
+                    width: 100%;
+                }
+
+                figure>span {
+                    font-size: 0;
+                }
+
+                .row {
+                    column-count: 2;
+                }"""
 
     def __init__(self, path = ''):
-        try:
-            self.read_style(path)
-        except FileNotFoundError:
-            if path:
-                print(f"Oops! {path} style not found. Use default style.")
-            else:
-                self.read_style('FifthAvenue')
+        if path:
+            try:
+                self.read_style(path)
+            except FileNotFoundError:
+                print(f"Oops! {path} style not found or broken. Use default style.")
+        self.read_default_style() # if style not found
         return
-
-

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -8,31 +8,34 @@ def read_stylesheets(path: pathlib.Path) -> list:
     else:
         return []
 
+
 def read_css(path: pathlib.Path):
     return path.read_text()
 
+
 class Style:
-    def __init__(self, style = ''):
+    def __init__(self, style=''):
         if style:
             try:
                 self.read_style(style)
-            except (FileNotFoundError, StopIteration) as e:
-                print(f"Oops! {style} style not found or broken. Use default style.")
-        self.read_default_style() # if style not found
+            except (FileNotFoundError, StopIteration):
+                print(f"Oops! {style} style not found or broken. "
+                      "Use default style.")
+        self.read_default_style()  # if style not found
         return
-    
+
     def get_stylesheets(self) -> list:
-        return getattr(self,"_stylesheets",[])
+        return getattr(self, "_stylesheets", [])
 
     def get_css(self, font_size: int = None):
-        font_size=str(font_size)
+        font_size = str(font_size)
         if font_size:
-            self._css+= f"""
+            self._css += f"""
         .stories {{
-            font-size: {font_size}pt !important; 
+            font-size: {font_size}pt !important;
         }}
         article>h4.byline {{
-            font-size: {font_size}pt !important; 
+            font-size: {font_size}pt !important;
         }}
         """
         return getattr(self, "_css", "")
@@ -44,14 +47,14 @@ class Style:
                 self._stylesheets = read_stylesheets(path/"stylesheets.txt")
                 self._css = read_css(next(path.glob("*.css")))
         elif path.with_suffix('.css').is_file():
-                self._stylesheets = [] 
-                self._css = read_css(path.with_suffix('.css'))
+            self._stylesheets = []
+            self._css = read_css(path.with_suffix('.css'))
 
-    def read_default_style(self): #code copied from FifthAvenueStyle
+    def read_default_style(self):  # code copied from FifthAvenueStyle
         if not hasattr(self, '_css'):
             self._stylesheets = [
-            "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap",
-        ]
+                                 "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap"
+                                 ]
             self._css = """
                 @page {
                     margin-top: 0.5in;
@@ -166,5 +169,3 @@ class Style:
                 .row {
                     column-count: 2;
                 }"""
-
-    

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -1,393 +1,47 @@
-class Style:
-    def get_stylesheets(self) -> list:
-        ...
-
-    def get_css(self, font_size: int = 14):
-        ...
+import pathlib
 
 
-class AutumnStyle(Style):
-    def get_stylesheets(self) -> list:
-        return [
-            "https://fonts.googleapis.com/css?family=Oswald",
-            "https://fonts.googleapis.com/css?family=Playfair+Display",
-        ]
-
-    def get_name(self):
-        return "Autumn"
-
-    def get_css(self, font_size: int = 14):
-        return (
-            """
-        @page {
-            margin-top: 0.5in;
-            margin-right: 0.2in;
-            margin-left: 0.65in;
-            margin-bottom: 0.2in;
-        }
-
-        body {
-            font-family: "Playfair Display";
-        }
-
-        .header {
-            padding: 1em;
-            height: 10em;
-        }
-
-        .header div {
-            float: left;
-            display: block;
-        }
-
-        .header .ear {
-            float: right;
-        }
-
-        ul, li, ol {
-            margin-left: 0; padding-left: 0.15em;
-        }
-
-        .stories {
-            font-size: """
-            + str(font_size)
-            + """pt;
-        }
-
-        .ear article {
-            border: 1px groove black;
-            padding: 1em;
-            margin: 1em;
-            font-size: 11pt;
-        }
-        .ear article h1 {
-            font-family: "Playfair Display";
-            font-size: 10pt;
-            font-weight: normal;
-        }
-
-        article {
-            text-align: justify;
-            line-height: 1.25em;
-        }
-
-        .longform {
-            page-break-after: always;
-        }
-
-        article>h1 {
-            font-family: "Oswald";
-            font-weight: 400;
-            font-size: 23pt;
-            text-indent: 0;
-            margin-bottom: 0.25em;
-            line-height: 1.2em;
-            text-align: left;
-        }
-        article>h1.priority-low {
-            font-family: "Oswald";
-            font-size: 18pt;
-            font-weight: 400;
-            text-indent: 0;
-            border-bottom: 1px solid #dedede;
-            margin-bottom: 0.15em;
-        }
-
-        article>h4.byline {
-            font-family: "Oswald";
-            font-size: """
-            + str(font_size)
-            + """pt;
-            font-weight: 400;
-            text-indent: 0;
-            border-bottom: 1px solid #dedede;
-        }
-
-        article>h3 {
-            font-family: "Oswald";
-            font-weight: 400;
-            font-size: 18pt;
-            text-indent: 0;
-        }
-
-        section>h1,
-        section>h2,
-        section>h3,
-        section>h4,
-        section>h5 {
-            border-left: 5px solid #dedede;
-            padding-left: 1em;
-        }
-
-        figure {
-            border: 1px solid black;
-            text-indent: 0;
-            width: auto;
-        }
-
-        .stories article.story img {
-            width: 100%;
-        }
-
-        figure>span {
-            font-size: 0;
-        }
-
-        .row {
-            column-count: 2;
-        }
-
-        """
-        )
-
-
-class FifthAvenueStyle(Style):
-    def get_stylesheets(self) -> list:
-        return [
-            "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap",
-        ]
-
-    def get_name(self):
-        return "FifthAvenue"
-
-    def get_css(self, font_size: int = 14):
-        return (
-            """
-        @page {
-            margin-top: 0.5in;
-            margin-right: 0.2in;
-            margin-left: 0.65in;
-            margin-bottom: 0.2in;
-        }
-
-        body {
-            font-family: "Open Sans";
-        }
-
-        .header {
-            padding: 1em;
-            height: 10em;
-        }
-
-        .header div {
-            float: left;
-            display: block;
-        }
-
-        .header .ear {
-            float: right;
-        }
-
-        ul, li, ol {
-            margin-left: 0; padding-left: 0.15em;
-        }
-
-        .stories {
-            font-size: """
-            + str(font_size)
-            + """pt;
-        }
-
-        .ear article {
-            border: 1px groove black;
-            padding: 1em;
-            margin: 1em;
-            font-size: 11pt;
-        }
-        .ear article h1 {
-            font-family: "Source Serif Pro";
-            font-size: 10pt;
-            font-weight: normal;
-        }
-
-        article {
-            text-align: justify;
-            line-height: 1.3em;
-        }
-
-        .longform {
-            page-break-after: always;
-        }
-
-        article>h1 {
-            font-family: "Source Serif Pro";
-            font-weight: 400;
-            font-size: 23pt;
-            text-indent: 0;
-            margin-bottom: 0.25em;
-            line-height: 1.2em;
-            text-align: left;
-        }
-        article>h1.priority-low {
-            font-family: "Open Sans";
-            font-size: 18pt;
-            font-weight: 400;
-            text-indent: 0;
-            border-bottom: 1px solid #dedede;
-            margin-bottom: 0.15em;
-        }
-
-        article>h4.byline {
-            font-family: "Open Sans";
-            font-size: """
-            + str(font_size)
-            + """pt;
-            font-weight: 400;
-            text-indent: 0;
-            border-bottom: 1px solid #dedede;
-        }
-
-        article>h3 {
-            font-family: "Open Sans";
-            font-weight: 400;
-            font-size: 18pt;
-            text-indent: 0;
-        }
-
-        section>h1,
-        section>h2,
-        section>h3,
-        section>h4,
-        section>h5 {
-            border-left: 5px solid #dedede;
-            padding-left: 1em;
-        }
-
-        figure {
-            border: 1px solid black;
-            text-indent: 0;
-            width: auto;
-        }
-
-        .stories article.story img {
-            width: 100%;
-        }
-
-        figure>span {
-            font-size: 0;
-        }
-
-        .row {
-            column-count: 2;
-        }
-
-        """
-        )
-
-
-class AcademyStyle(Style):
-    def get_stylesheets(self) -> list:
+def read_stylesheets(path: pathlib.Path) -> list:
+    if (path/"stylesheets.txt").is_file():
+        return (path / "stylesheets.txt").read_text()\
+            .strip("\n").split("\n")
+    else:
         return []
 
-    def get_name(self):
-        return "Academy"
+def read_css(path: pathlib.Path):
+    return (path / "stylesheet.css") \
+        .read_text()
 
-    def get_css(self, font_size: int = 14):
-        return (
-            """
-        @page {
-            margin-top: 0.5in;
-            margin-right: 0.2in;
-            margin-left: 0.65in;
-            margin-bottom: 0.2in;
-        }
+class Style:
+    def get_stylesheets(self) -> list:
+        return getattr(self,"__stylesheets__","")
 
-        body {
-            font-family: "Times New Roman";
-        }
-
-        .header {
-            padding: 1em;
-            height: 10em;
-        }
-
-        .header div {
-            float: left;
-            display: block;
-        }
-
-        .header .ear {
-            float: right;
-        }
-
-        .stories {
-            font-size: """
-            + str(font_size)
-            + """pt;
-        }
-
-        .ear article {
-            border: 3px groove black;
-            padding: 1em;
-            margin: 1em;
-            font-size: 11pt;
-        }
-        .ear article h1 {
-            font-family: "Times New Roman";
-            font-size: 10pt;
-            font-weight: normal;
-        }
-
-        article {
-            text-align: left;
-            line-height: 1.4em;
-        }
-
-        article>h1 {
-            font-family: "Times New Roman";
-            font-weight: 400;
-            font-size: 23pt;
-            text-indent: 0;
-            margin-bottom: 0.25em;
-            line-height: 1.2em;
-            text-align: left;
-        }
-        article>h1.priority-low {
-            font-family: "Times New Roman";
-            font-size: 18pt;
-            font-weight: 400;
-            text-indent: 0;
-            margin-bottom: 0.15em;
-        }
-
-        article>h4.byline {
-            font-family: "Times New Roman";
-            font-size: """
-            + str(font_size)
-            + """pt;
-            font-weight: 400;
-            text-indent: 0;
-        }
-
-        article>h3 {
-            font-family: "Times New Roman";
-            font-weight: 400;
-            font-size: 18pt;
-            text-indent: 0;
-        }
-
-        section>h1,
-        section>h2,
-        section>h3,
-        section>h4,
-        section>h5 {
-            border-left: 5px solid #dedede;
-            padding-left: 1em;
-        }
-
-        figure {
-            border: 1px solid black;
-            text-indent: 0;
-            width: auto;
-        }
-
-        .stories article.story img {
-            width: 100%;
-        }
-
-        figure>span {
-            font-size: 0;
-        }
-
+    def get_css(self, font_size: int = None):
+        font_size=str(font_size)
+        if font_size:
+            self.__css__+= f"""
+        .stories {{
+            font-size: {font_size}pt !important; 
+        }}
+        article>h4.byline {{
+            font-size: {font_size}pt !important; 
+        }}
         """
-        )
+        return getattr(self, "__css__", "")
+
+    def read_style(self, path):
+        path = pathlib.Path("./styles/") / path
+        self.__stylesheets__ = read_stylesheets(path)
+        self.__css__ = read_css(path)
+
+    def __init__(self, path = ''):
+        try:
+            self.read_style(path)
+        except FileNotFoundError:
+            if path:
+                print(f"Oops! {path} style not found. Use default style.")
+            else:
+                self.read_style('FifthAvenue')
+        return
+
+

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -3,8 +3,7 @@ import pathlib
 
 def read_stylesheets(path: pathlib.Path) -> list:
     if path.is_file():
-        return path.read_text()\
-            .strip("\n").split("\n")
+        return path.read_text().strip("\n").split("\n")
     else:
         return []
 
@@ -14,13 +13,12 @@ def read_css(path: pathlib.Path):
 
 
 class Style:
-    def __init__(self, style=''):
+    def __init__(self, style=""):
         if style:
             try:
                 self.read_style(style)
             except (FileNotFoundError, StopIteration):
-                print(f"Oops! {style} style not found or broken. "
-                      "Use default style.")
+                print(f"Oops! {style} style not found or broken. Use default style.")
         self.read_default_style()  # if style not found
         return
 
@@ -43,18 +41,18 @@ class Style:
     def read_style(self, style):
         path = pathlib.Path("./styles/") / style
         if path.is_dir():
-            if not hasattr(self, '_css'):
-                self._stylesheets = read_stylesheets(path/"stylesheets.txt")
+            if not hasattr(self, "_css"):
+                self._stylesheets = read_stylesheets(path / "stylesheets.txt")
                 self._css = read_css(next(path.glob("*.css")))
-        elif path.with_suffix('.css').is_file():
+        elif path.with_suffix(".css").is_file():
             self._stylesheets = []
-            self._css = read_css(path.with_suffix('.css'))
+            self._css = read_css(path.with_suffix(".css"))
 
     def read_default_style(self):  # code copied from FifthAvenueStyle
-        if not hasattr(self, '_css'):
+        if not hasattr(self, "_css"):
             self._stylesheets = [
-                                 "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap"
-                                 ]
+                "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap"
+            ]
             self._css = """
                 @page {
                     margin-top: 0.5in;

--- a/goosepaper/util.py
+++ b/goosepaper/util.py
@@ -12,6 +12,7 @@ def htmlize(text: Union[str, List[str]]) -> str:
     #   * Escaping
     #   * Paragraph delims
     #   * Remove illegal elements
+    text = text.replace("<br />", "")
     if isinstance(text, list):
         return "".join([f"<p>{line}</p>" for line in text])
     return f"<p>{text}</p>"

--- a/goosepaper/util.py
+++ b/goosepaper/util.py
@@ -12,7 +12,6 @@ def htmlize(text: Union[str, List[str]]) -> str:
     #   * Escaping
     #   * Paragraph delims
     #   * Remove illegal elements
-    text = text.replace("<br />", "")
     if isinstance(text, list):
         return "".join([f"<p>{line}</p>" for line in text])
     return f"<p>{text}</p>"

--- a/manifest.in
+++ b/manifest.in
@@ -1,0 +1,1 @@
+recursive-include styles/ *

--- a/styles/Academy/stylesheet.css
+++ b/styles/Academy/stylesheet.css
@@ -1,0 +1,85 @@
+@page {
+    margin-top: 0.5in;
+    margin-right: 0.2in;
+    margin-left: 0.65in;
+    margin-bottom: 0.2in;
+}
+body {
+    font-family: "Times New Roman";
+}
+.header {
+    padding: 1em;
+    height: 10em;
+}
+.header div {
+    float: left;
+    display: block;
+}
+.header .ear {
+    float: right;
+}
+.stories {
+    font-size: 14pt;
+}
+.ear article {
+    border: 3px groove black;
+    padding: 1em;
+    margin: 1em;
+    font-size: 11pt;
+}
+.ear article h1 {
+    font-family: "Times New Roman";
+    font-size: 10pt;
+    font-weight: normal;
+}
+article {
+    text-align: left;
+    line-height: 1.4em;
+}
+article>h1 {
+    font-family: "Times New Roman";
+    font-weight: 400;
+    font-size: 23pt;
+    text-indent: 0;
+    margin-bottom: 0.25em;
+    line-height: 1.2em;
+    text-align: left;
+}
+article>h1.priority-low {
+    font-family: "Times New Roman";
+    font-size: 18pt;
+    font-weight: 400;
+    text-indent: 0;
+    margin-bottom: 0.15em;
+}
+article>h4.byline {
+    font-family: "Times New Roman";
+    font-size: 14pt;
+    font-weight: 400;
+    text-indent: 0;
+}
+article>h3 {
+    font-family: "Times New Roman";
+    font-weight: 400;
+    font-size: 18pt;
+    text-indent: 0;
+}
+section>h1,
+section>h2,
+section>h3,
+section>h4,
+section>h5 {
+    border-left: 5px solid #dedede;
+    padding-left: 1em;
+}
+figure {
+    border: 1px solid black;
+    text-indent: 0;
+    width: auto;
+}
+.stories article.story img {
+    width: 100%;
+}
+figure>span {
+    font-size: 0;
+}

--- a/styles/Autumn/stylesheet.css
+++ b/styles/Autumn/stylesheet.css
@@ -1,0 +1,96 @@
+@page {
+    margin-top: 0.5in;
+    margin-right: 0.2in;
+    margin-left: 0.65in;
+    margin-bottom: 0.2in;
+}
+body {
+    font-family: "Playfair Display";
+}
+.header {
+    padding: 1em;
+    height: 10em;
+}
+.header div {
+    float: left;
+    display: block;
+}
+.header .ear {
+    float: right;
+}
+ul, li, ol {
+    margin-left: 0; padding-left: 0.15em;
+}
+.stories {
+    font-size: 14pt;
+}
+.ear article {
+    border: 1px groove black;
+    padding: 1em;
+    margin: 1em;
+    font-size: 11pt;
+}
+.ear article h1 {
+    font-family: "Playfair Display";
+    font-size: 10pt;
+    font-weight: normal;
+}
+article {
+    text-align: justify;
+    line-height: 1.25em;
+}
+.longform {
+    page-break-after: always;
+}
+article>h1 {
+    font-family: "Oswald";
+    font-weight: 400;
+    font-size: 23pt;
+    text-indent: 0;
+    margin-bottom: 0.25em;
+    line-height: 1.2em;
+    text-align: left;
+}
+article>h1.priority-low {
+    font-family: "Oswald";
+    font-size: 18pt;
+    font-weight: 400;
+    text-indent: 0;
+    border-bottom: 1px solid #dedede;
+    margin-bottom: 0.15em;
+}
+article>h4.byline {
+    font-family: "Oswald";
+    font-size: 14pt;
+    font-weight: 400;
+    text-indent: 0;
+    border-bottom: 1px solid #dedede;
+}
+article>h3 {
+    font-family: "Oswald";
+    font-weight: 400;
+    font-size: 18pt;
+    text-indent: 0;
+}
+section>h1,
+section>h2,
+section>h3,
+section>h4,
+section>h5 {
+    border-left: 5px solid #dedede;
+    padding-left: 1em;
+}
+figure {
+    border: 1px solid black;
+    text-indent: 0;
+    width: auto;
+}
+.stories article.story img {
+    width: 100%;
+}
+figure>span {
+    font-size: 0;
+}
+.row {
+    column-count: 2;
+}

--- a/styles/Autumn/stylesheets.txt
+++ b/styles/Autumn/stylesheets.txt
@@ -1,0 +1,2 @@
+https://fonts.googleapis.com/css?family=Oswald
+https://fonts.googleapis.com/css?family=Playfair+Display

--- a/styles/FifthAvenue/stylesheet.css
+++ b/styles/FifthAvenue/stylesheet.css
@@ -1,0 +1,96 @@
+@page {
+    margin-top: 0.5in;
+    margin-right: 0.2in;
+    margin-left: 0.65in;
+    margin-bottom: 0.2in;
+}
+body {
+    font-family: "Open Sans";
+}
+.header {
+    padding: 1em;
+    height: 10em;
+}
+.header div {
+    float: left;
+    display: block;
+}
+.header .ear {
+    float: right;
+}
+ul, li, ol {
+    margin-left: 0; padding-left: 0.15em;
+}
+.stories {
+    font-size: 14pt;
+}
+.ear article {
+    border: 1px groove black;
+    padding: 1em;
+    margin: 1em;
+    font-size: 11pt;
+}
+.ear article h1 {
+    font-family: "Source Serif Pro";
+    font-size: 10pt;
+    font-weight: normal;
+}
+article {
+    text-align: justify;
+    line-height: 1.3em;
+}
+.longform {
+    page-break-after: always;
+}
+article>h1 {
+    font-family: "Source Serif Pro";
+    font-weight: 400;
+    font-size: 23pt;
+    text-indent: 0;
+    margin-bottom: 0.25em;
+    line-height: 1.2em;
+    text-align: left;
+}
+article>h1.priority-low {
+    font-family: "Open Sans";
+    font-size: 18pt;
+    font-weight: 400;
+    text-indent: 0;
+    border-bottom: 1px solid #dedede;
+    margin-bottom: 0.15em;
+}
+article>h4.byline {
+    font-family: "Open Sans";
+    font-size: 14pt;
+    font-weight: 400;
+    text-indent: 0;
+    border-bottom: 1px solid #dedede;
+}
+article>h3 {
+    font-family: "Open Sans";
+    font-weight: 400;
+    font-size: 18pt;
+    text-indent: 0;
+}
+section>h1,
+section>h2,
+section>h3,
+section>h4,
+section>h5 {
+    border-left: 5px solid #dedede;
+    padding-left: 1em;
+}
+figure {
+    border: 1px solid black;
+    text-indent: 0;
+    width: auto;
+}
+.stories article.story img {
+    width: 100%;
+}
+figure>span {
+    font-size: 0;
+}
+.row {
+    column-count: 2;
+}

--- a/styles/FifthAvenue/stylesheets.txt
+++ b/styles/FifthAvenue/stylesheets.txt
@@ -1,0 +1,1 @@
+https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,400;0,700;1,400;1,700&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap


### PR DESCRIPTION
The styles were hard-coded in the package; reading them from a styles folder will make goosepaper much easier to customize.

These codes basically do one thing: look for a user-defined style in styles folder, and read it on-the-fly. It keeps one hard-coded style for robustness (originally FifthAvenue; now it will only be used when no/wrong style is configured).

---

I closed the previous PR as it was a bit messy. Glad you like this!

I have a small piece [here](https://github.com/zerone01y/goosepaper/blob/master/README.md#edit-your-own-styles) for instructions but it is not included in this PR, as I later found out you have a doc for customising (btw we should put a link to this doc in readme). But just let me know if you want to add the instructions.