### PR TITLE
styles: add page size, review margins

### DIFF
--- a/styles/Academy/stylesheet.css
+++ b/styles/Academy/stylesheet.css
@@ -1,8 +1,9 @@
 @page {
-    margin-top: 0.5in;
-    margin-right: 0.2in;
-    margin-left: 0.65in;
-    margin-bottom: 0.2in;
+    size: 702pt 936pt;
+    margin-top: 30mm;
+    margin-bottom: 20mm;
+    margin-left: 20mm;
+    margin-right: 10mm;
 }
 body {
     font-family: "Times New Roman";

--- a/styles/FifthAvenue/stylesheet.css
+++ b/styles/FifthAvenue/stylesheet.css
@@ -1,15 +1,16 @@
 @page {
-    margin-top: 0.5in;
-    margin-right: 0.2in;
-    margin-left: 0.65in;
-    margin-bottom: 0.2in;
+    size: 702pt 936pt;
+    margin-top: 30mm;
+    margin-bottom: 20mm;
+    margin-left: 20mm;
+    margin-right: 10mm;
 }
 body {
     font-family: "Open Sans";
 }
 .header {
-    padding: 1em;
-    height: 10em;
+    padding: -6em;
+    height: 6em;
 }
 .header div {
     float: left;
@@ -93,4 +94,5 @@ figure>span {
 }
 .row {
     column-count: 2;
+    column-gap: 2rem;
 }


### PR DESCRIPTION
weasy print's css supports the @page 'size' attribute, allowing us to specify a pdf size different from the default A4 size.

The remarkable is 1872 x 1404 pixels, but using that makes fonts too small without further adjusments so setting a page size of half that is easier to use.

Having a proper page size, we can re-adjust the margins to better fit the new format. Also made the space between columns in FifthAvenue slightly bigger as a matter of taste.

Fixes: #75

------
Sorry for the delay, here's the PR. Since I brought it up in the issue I've also done a similar modification to Academy as some documents render better with a single column.

The margins are up to discussion (sorry for switching to metrics, I couldn't understand inches if my life depends on it -- might want to switch to something like em for compromise if you're similar the other way around :P) ; I honestly didn't spend very long fiddling with them.
I'd attach a sample document with that but github doesn't seem to allow attachments here, so I guess we'll do without...