### PR TITLE
fix: correct rss feed handling for large feed counts

### DIFF
--- a/goosepaper/storyprovider/bluesky.py
+++ b/goosepaper/storyprovider/bluesky.py
@@ -35,13 +35,13 @@ class BlueskyStoryProvider(StoryProvider):
             else None
         )
 
-    def get_stories(self, limit: int = 5, **kwargs) -> List[Story]:
+    def get_stories(self) -> List[Story]:
         response = requests.get(
             self.feed_url,
             params={
                 "actor": self.username,
                 "filter": self.feed_filter,
-                "limit": min(self.limit, limit),
+                "limit": self.limit,
             },
             headers={"User-Agent": f"goosepaper/{__version__}"},
             timeout=20,
@@ -58,7 +58,7 @@ class BlueskyStoryProvider(StoryProvider):
                 continue
 
             stories.append(story)
-            if len(stories) >= min(self.limit, limit):
+            if len(stories) >= self.limit:
                 break
 
         return stories

--- a/goosepaper/storyprovider/mastodon.py
+++ b/goosepaper/storyprovider/mastodon.py
@@ -23,9 +23,9 @@ class MastodonStoryProvider(StoryProvider):
             else None
         )
 
-    def get_stories(self, limit: int = 5, **kwargs) -> List[Story]:
+    def get_stories(self) -> List[Story]:
         feed = feedparser.parse(self.feed_url)
-        limit = min(limit, self.limit, len(feed.entries))
+        limit = min(self.limit, len(feed.entries))
         if limit == 0:
             print(f"Sad honk :/ No entries found for feed {self.feed_url}...")
 

--- a/goosepaper/storyprovider/reddit.py
+++ b/goosepaper/storyprovider/reddit.py
@@ -21,7 +21,7 @@ class RedditHeadlineStoryProvider(StoryProvider):
         subreddit = subreddit[2:] if subreddit.startswith("r/") else subreddit
         self.subreddit = subreddit
 
-    def get_stories(self, limit: int = 20, **kwargs) -> List[Story]:
+    def get_stories(self) -> List[Story]:
         response = requests.get(
             f"https://www.reddit.com/r/{self.subreddit}.rss",
             headers={"User-Agent": f"goosepaper/{__version__}"},
@@ -29,7 +29,7 @@ class RedditHeadlineStoryProvider(StoryProvider):
         )
         response.raise_for_status()
         feed = feedparser.parse(response.content)
-        limit = min(self.limit, len(feed.entries), limit)
+        limit = min(self.limit, len(feed.entries))
         stories = []
         for entry in feed.entries:
             try:

--- a/goosepaper/storyprovider/rss.py
+++ b/goosepaper/storyprovider/rss.py
@@ -42,9 +42,9 @@ class RSSFeedStoryProvider(StoryProvider):
             else None
         )
 
-    def get_stories(self, limit: int = 5, **kwargs) -> List[Story]:
+    def get_stories(self) -> List[Story]:
         feed = feedparser.parse(self.feed_url)
-        limit = min(limit, self.limit, len(feed.entries))
+        limit = min(self.limit, len(feed.entries))
         if limit == 0:
             print(f"Sad honk :/ No entries found for feed {self.feed_url}...")
 

--- a/goosepaper/storyprovider/storyprovider.py
+++ b/goosepaper/storyprovider/storyprovider.py
@@ -8,7 +8,7 @@ class StoryProvider(abc.ABC):
     An abstract class for a class that provides stories to be rendered.
     """
 
-    def get_stories(self, limit: int = 5) -> List["Story"]:
+    def get_stories(self) -> List["Story"]:
         """
         Get a list of stories from this Provider.
         """
@@ -27,10 +27,10 @@ class CustomTextStoryProvider(StoryProvider):
         self.limit = limit
         self.headline = headline or "Lorem Ipsum Dolor Sit Amet"
 
-    def get_stories(self, limit: int = 5, **kwargs) -> List[Story]:
+    def get_stories(self) -> List[Story]:
         return [
             Story(headline=self.headline, body_text=self.text)
-            for _ in range(min(self.limit, limit))
+            for _ in range(self.limit)
         ]
 
 

--- a/goosepaper/storyprovider/test_bluesky.py
+++ b/goosepaper/storyprovider/test_bluesky.py
@@ -67,8 +67,8 @@ def test_bluesky_provider_uses_public_author_feed(monkeypatch):
 
     monkeypatch.setattr(bluesky.requests, "get", fake_get)
 
-    provider = bluesky.BlueskyStoryProvider("jordan.matelsky.com", limit=4)
-    stories = provider.get_stories(limit=2)
+    provider = bluesky.BlueskyStoryProvider("jordan.matelsky.com", limit=2)
+    stories = provider.get_stories()
 
     assert seen["url"] == "https://public.api.bsky.app/xrpc/app.bsky.feed.getAuthorFeed"
     assert seen["params"] == {
@@ -99,7 +99,7 @@ def test_bluesky_provider_can_exclude_replies(monkeypatch):
         "jordan.matelsky.com",
         include_replies=False,
     )
-    stories = provider.get_stories(limit=2)
+    stories = provider.get_stories()
 
     assert seen["params"]["filter"] == "posts_no_replies"
     assert len(stories) == 1
@@ -123,7 +123,7 @@ def test_bluesky_provider_skips_reposts(monkeypatch):
     )
 
     provider = bluesky.BlueskyStoryProvider("jordan.matelsky.com")
-    stories = provider.get_stories(limit=5)
+    stories = provider.get_stories()
 
     assert len(stories) == 1
     assert stories[0].body_html == "<p>An original post</p>"
@@ -154,7 +154,7 @@ def test_bluesky_provider_honors_since_days_ago(monkeypatch):
         "infinitescream.bsky.social",
         since_days_ago=30,
     )
-    stories = provider.get_stories(limit=5)
+    stories = provider.get_stories()
 
     assert len(stories) == 1
     assert stories[0].body_html == "<p>Recent post</p>"

--- a/goosepaper/storyprovider/test_reddit.py
+++ b/goosepaper/storyprovider/test_reddit.py
@@ -55,7 +55,7 @@ def test_reddit_provider_fetches_feed_with_requests_and_user_agent(monkeypatch):
     )
 
     provider = reddit.RedditHeadlineStoryProvider("/r/news", limit=3)
-    stories = provider.get_stories(limit=2)
+    stories = provider.get_stories()
 
     assert seen["url"] == "https://www.reddit.com/r/news.rss"
     assert seen["timeout"] == 20
@@ -92,7 +92,7 @@ def test_reddit_provider_filters_old_entries(monkeypatch):
     )
 
     provider = reddit.RedditHeadlineStoryProvider("news", since_days_ago=30)
-    stories = provider.get_stories(limit=5)
+    stories = provider.get_stories()
 
     assert len(stories) == 1
     assert stories[0].plain_text() == "Recent story"

--- a/goosepaper/storyprovider/test_rss.py
+++ b/goosepaper/storyprovider/test_rss.py
@@ -69,7 +69,7 @@ def test_rss_provider_prefers_embedded_feed_content(monkeypatch):
     monkeypatch.setattr(rss.requests, "get", fail_get)
 
     provider = rss.RSSFeedStoryProvider("https://example.com/feed.xml")
-    stories = provider.get_stories(limit=1)
+    stories = provider.get_stories()
 
     assert stories[0].headline == "Feed title"
     assert stories[0].body_html == "<p>Embedded story body</p>"
@@ -103,7 +103,7 @@ def test_rss_provider_summary_mode_uses_feed_summary(monkeypatch):
         "https://example.com/feed.xml",
         body_source="summary",
     )
-    stories = provider.get_stories(limit=1)
+    stories = provider.get_stories()
 
     assert stories[0].body_html == "<p>Feed summary only</p>"
 
@@ -137,7 +137,7 @@ def test_rss_provider_content_mode_uses_feed_content_without_article_fetch(
         "https://example.com/feed.xml",
         body_source="content",
     )
-    stories = provider.get_stories(limit=1)
+    stories = provider.get_stories()
 
     assert stories[0].body_html == "<p>Embedded story body</p>"
 
@@ -160,7 +160,7 @@ def test_rss_provider_content_mode_falls_back_to_summary(monkeypatch):
         "https://example.com/feed.xml",
         body_source="content",
     )
-    stories = provider.get_stories(limit=1)
+    stories = provider.get_stories()
 
     assert stories[0].body_html == "<p>Feed summary only</p>"
 
@@ -195,7 +195,7 @@ def test_rss_provider_passes_text_to_readability(monkeypatch):
     monkeypatch.setattr(rss, "Document", FakeDocument)
 
     provider = rss.RSSFeedStoryProvider("https://example.com/feed.xml")
-    stories = provider.get_stories(limit=1)
+    stories = provider.get_stories()
 
     assert isinstance(seen["html"], str)
     assert stories[0].headline == "Readable title"
@@ -244,7 +244,7 @@ def test_rss_provider_article_mode_fetches_article_even_when_feed_has_content(
         "https://example.com/feed.xml",
         body_source="article",
     )
-    stories = provider.get_stories(limit=1)
+    stories = provider.get_stories()
 
     assert seen["requests"] == 1
     assert stories[0].headline == "Readable title"
@@ -269,7 +269,7 @@ def test_rss_provider_falls_back_to_feed_summary_when_readability_fails(monkeypa
     monkeypatch.setattr(rss, "Document", BrokenDocument)
 
     provider = rss.RSSFeedStoryProvider("https://example.com/feed.xml")
-    stories = provider.get_stories(limit=1)
+    stories = provider.get_stories()
 
     assert stories[0].headline == "Feed title"
     assert stories[0].body_html == "<p>Feed summary</p>"
@@ -298,7 +298,7 @@ def test_rss_provider_can_hide_all_bylines(monkeypatch):
         "https://example.com/feed.xml",
         byline="none",
     )
-    stories = provider.get_stories(limit=2)
+    stories = provider.get_stories()
 
     assert stories[0].byline is None
     assert stories[1].byline is None
@@ -326,7 +326,7 @@ def test_rss_provider_can_show_only_first_byline(monkeypatch):
         "https://example.com/feed.xml",
         byline="first",
     )
-    stories = provider.get_stories(limit=2)
+    stories = provider.get_stories()
 
     assert stories[0].byline == "example.com"
     assert stories[1].byline is None

--- a/goosepaper/storyprovider/weather.py
+++ b/goosepaper/storyprovider/weather.py
@@ -18,7 +18,7 @@ class MetaWeatherStoryProvider(StoryProvider):
     def CtoF(self, temp: float) -> float:
         return (temp * 9 / 5) + 32
 
-    def get_stories(self, limit: int = 1, **kwargs) -> List[Story]:
+    def get_stories(self) -> List[Story]:
         weatherReq = requests.get(
             f"https://www.metaweather.com/api/location/{self.woe}/"
         ).json()
@@ -336,7 +336,7 @@ class OpenMeteoWeatherStoryProvider(StoryProvider):
             return f"{hour}{suffix}"
         return f"{hour}:{point_time.minute:02d}{suffix}"
 
-    def get_stories(self, limit: int = 1, **kwargs) -> List[Story]:
+    def get_stories(self) -> List[Story]:
         response = requests.get(
             "https://api.open-meteo.com/v1/forecast",
             params=self._build_params(),


### PR DESCRIPTION
# Summary
Hello! I've got another suggestion. Let me know what you think- it's much broader than my last PR, so probably needs a bit more careful consideration.

Feed sizes greater than the feed object's default limit would still revert to the feed object's default limit due to the `min` call. By removing the limit from `get_stories`, it simplifies the code and deletes the requirement to fix this logic at all. I discovered this by passing an RSS feed limit of 15, which when fed into `get_stories`, was compared against the feed object's default stateful limit of 5, which took precedent in the `min` call to determine the limit. 

## Fixes
One option is to change from duplicating the default int limits in the `get_stories` method to `Option[int] = None`, and then add a conditional check when `None` to default to using `self.limit`. However, this felt like a code smell so instead I opted to just delete the limit argument entirely since it was only used in testing. 

## Verification
As seen here, if a limit of 15 is supplied, the RSS feed correctly collects them instead of limiting to 5. 

Source line:

```
        {
            "type": "rss",
            "url": "https://feeds.arstechnica.com/arstechnica/index",
            "limit": 15,
            "byline": "first",
            "body_source": "article"
        }
```

Resulting document:

<img width="553" height="738" alt="image" src="https://github.com/user-attachments/assets/f5ae1707-0b02-4cff-afdd-5eed607e8403" />


