### PR TITLE
Fix crash when the Wikipedia current events feed returns no entries

### DIFF
--- a/goosepaper/storyprovider/test_wikipedia.py
+++ b/goosepaper/storyprovider/test_wikipedia.py
@@ -1,0 +1,14 @@
+from . import wikipedia
+
+
+def test_empty_feed_returns_no_stories_instead_of_crashing(monkeypatch):
+    """A transient network hiccup (or the upstream feed briefly returning zero entries) should
+    degrade to "no story this run", the same way other providers handle an empty feed - not an
+    unhandled IndexError out of feed.entries[0]."""
+    monkeypatch.setattr(
+        wikipedia.feedparser, "parse", lambda *a, **kw: wikipedia.feedparser.FeedParserDict(entries=[])
+    )
+
+    stories = wikipedia.WikipediaCurrentEventsStoryProvider().get_stories()
+
+    assert stories == []

--- a/goosepaper/storyprovider/wikipedia.py
+++ b/goosepaper/storyprovider/wikipedia.py
@@ -19,6 +19,9 @@ class WikipediaCurrentEventsStoryProvider(StoryProvider):
         Get a list of current stories from Wikipedia.
         """
         feed = feedparser.parse("https://www.to-rss.xyz/wikipedia/current_events/")
+        if not feed.entries:
+            print("Sad honk :/ No entries found for the Wikipedia current events feed...")
+            return []
         # title = feed.entries[0].title
         title = "Today's Current Events"
         content = bs4.BeautifulSoup(feed.entries[0].summary, "lxml")


### PR DESCRIPTION
## What

`WikipediaCurrentEventsStoryProvider.get_stories()` indexes `feed.entries[0]` unconditionally. If the upstream feed (`to-rss.xyz/wikipedia/current_events`) returns zero entries — a transient network hiccup, a brief upstream outage, whatever — this raises an unhandled `IndexError` and kills the whole `get_stories()` call for every other provider in the same run, instead of just skipping this one source for today.

`RSSFeedStoryProvider` already handles an empty feed gracefully elsewhere in this codebase (prints a "no entries found" message and moves on). This PR brings `WikipediaCurrentEventsStoryProvider` in line with that existing pattern.

## Reproduction

```python
import unittest.mock as mock
from goosepaper.storyprovider import wikipedia

with mock.patch.object(
    wikipedia.feedparser, "parse",
    return_value=wikipedia.feedparser.FeedParserDict(entries=[]),
):
    wikipedia.WikipediaCurrentEventsStoryProvider().get_stories()
```

```Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File ".../goosepaper/storyprovider/wikipedia.py", line 24, in get_stories
    content = bs4.BeautifulSoup(feed.entries[0].summary, "lxml")
                                ~~~~~~~~~~~~^^^
IndexError: list index out of range
```

## Fix
Guard on feed.entries before indexing into it; return [] (no story this
run) if empty, matching the "Sad honk" message pattern already used for
empty RSS feeds.

## Testing
New regression test (test_wikipedia.py::test_empty_feed_returns_no_stories_instead_of_crashing) mocks feedparser.parse to return zero entries and asserts get_stories() returns [] instead of raising.
Full existing test suite still passes (73 passed).
Manually reproduced the crash on master and confirmed it's gone on this branch (see reproduction snippet above — same snippet, no exception, prints the "Sad honk" message instead).

## Scope
Minimal, single-purpose fix. Doesn't touch any other provider or change any public behavior for the non-empty-feed case.