### PR TITLE
Fix inline SVG icons overflowing their column

### DIFF
--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -282,6 +282,17 @@ def _base_print_css(
         height: auto;
     }}
 
+    /* Inline <svg> (decorative icons/illustrations some source sites embed directly in article
+    HTML) has no such constraint by default - unlike <img>, which browsers/WeasyPrint shrink to
+    fit an ancestor's width automatically in most contexts, an <svg> renders at its own
+    width/height (or viewBox-implied size) regardless of the column it landed in. Observed: a
+    corner-bracket icon rendering the better part of a page tall/wide in a narrow newspaper
+    column. Same fix as <img>: cap it to the column and let it scale down proportionally. */
+    svg {{
+        max-width: 100%;
+        height: auto;
+    }}
+
     .header {{
         position: relative;
         margin: 0 0 0.65rem;

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -293,6 +293,20 @@ def _base_print_css(
         height: auto;
     }}
 
+    /* max-width caps an SVG that's too big, but doesn't help one with no size at all: readability
+    (goosepaper's HTML extractor) strips width/height attributes from every <svg> during cleaning,
+    even ones the source page did give an explicit size (verified: readability.Document(html) with
+    an svg width="20px" height="20px" comes back with neither). A replaced element with only a
+    viewBox and no intrinsic width/height defaults to filling its container's available width -
+    turning a small UI icon (a code block's "copy"/"fullscreen" button, meant to render around
+    text-height) into a shape as wide as the column. Give it a small, text-relative default size
+    instead - covers every <svg> goosepaper ever sees, since none of them keep their width
+    attribute this far into the pipeline regardless of what the source page originally had. */
+    svg:not([width]) {{
+        width: 1em;
+        height: 1em;
+    }}
+
     .header {{
         position: relative;
         margin: 0 0 0.65rem;

--- a/goosepaper/test_styles.py
+++ b/goosepaper/test_styles.py
@@ -9,3 +9,15 @@ def test_svg_is_constrained_to_the_column_width():
 
     assert "svg {" in css
     assert "max-width: 100%" in css
+
+
+def test_unsized_svg_defaults_to_icon_size():
+    """readability strips width/height from every <svg> it cleans (verified separately against
+    the readability library itself), leaving only a viewBox. A replaced element with no intrinsic
+    size defaults to filling its container's available width - max-width: 100% alone doesn't stop
+    a small UI icon (a code block's copy/fullscreen button) from rendering as wide as the whole
+    column. It needs an actual default size, not just a ceiling."""
+    css = Style("FifthAvenue").get_css(page_profile="paper_pro", layout="2col")
+
+    assert "svg:not([width])" in css
+    assert "width: 1em" in css

--- a/goosepaper/test_styles.py
+++ b/goosepaper/test_styles.py
@@ -1,0 +1,11 @@
+from .styles import Style
+
+
+def test_svg_is_constrained_to_the_column_width():
+    """An inline <svg> pulled in from article HTML must not render at its own unconstrained
+    width/height - see the corner-bracket icon that rendered most of a page tall/wide in a
+    narrow column this was fixed for."""
+    css = Style("FifthAvenue").get_css(page_profile="paper_pro", layout="2col")
+
+    assert "svg {" in css
+    assert "max-width: 100%" in css


### PR DESCRIPTION
## What

Inline `<svg>` elements pulled in from article HTML (icons some source sites
embed directly, e.g. a code block's copy/fullscreen toggle) had no size
constraint. `<img>` already gets `max-width: 100%; height: auto` so it never
renders wider than its column - `<svg>` had no equivalent rule, so it
rendered at its own intrinsic size (or filled its container if it had none)
regardless of the column it landed in.

Two related cases, fixed in two commits on this branch:

1. **Oversized SVG** (explicit `width`/`height` from the source page): had
   no cap at all, could render most of a page tall/wide. Observed with a
   corner-bracket icon, repeated several times, from a real RSS-sourced
   article.
2. **Unsized SVG**: `max-width: 100%` alone doesn't help an SVG with *no*
   intrinsic size - a replaced element with only a `viewBox` defaults to
   filling its container's available width. This is actually the *common*
   case in practice: `readability` (goosepaper's own HTML extractor) strips
   `width`/`height` attributes from every `<svg>` it cleans, even ones the
   source page did give an explicit size - verified directly against
   `readability.Document()` with an `svg width="20px" height="20px"` input,
   which comes back with neither attribute. Observed in the wild: a Dev.to
   tutorial's per-code-block fullscreen-toggle icons (two per code block,
   several code blocks) turning 30+ pages of a 2-column newspaper into
   almost nothing but oversized icon shapes.


<img width="531" height="708" alt="image-1785354532402" src="https://github.com/user-attachments/assets/1c3a123e-9c1d-4578-a55c-1aa61a0b7337" />
<img width="531" height="708" alt="image-1785354538293" src="https://github.com/user-attachments/assets/aee53a9a-42a7-4e87-9aad-f959df3b35f3" />


## Reproduction

Rendered a minimal story through Goosepaper's real pipeline
(`FifthAvenue` style, `paper_pro` profile, `2col` layout) with two `<svg>`s:
one unsized (`viewBox` only, mimicking post-readability HTML), one with an
explicit `width="600" height="400"`.

**Before (master):** both render far larger than the column - the unsized
one fills roughly a third of a column, the oversized one bleeds well past
its column into the layout margin.

**After (this branch):** the unsized icon renders at a small, text-relative
size inline with the surrounding text; the oversized one is capped exactly
to the column width.

*(Screenshots attached to this PR - `svg_before.png` / `svg_after.png`,
same repro script, only the branch differs.)*

## Fix

- `svg { max-width: 100%; height: auto; }` - same treatment `<img>` already
  gets, for any SVG that does carry an explicit size.
- `svg:not([width]) { width: 1em; height: 1em; }` - a small, text-relative
  default for the common case of a completely unsized SVG, so it renders
  like the inline UI icon it usually is instead of filling the column.

## Testing

- Two new tests in `test_styles.py`:
  `test_svg_is_constrained_to_the_column_width` and
  `test_unsized_svg_defaults_to_icon_size`, asserting the generated CSS
  contains both rules.
- Full existing test suite passes (74 passed).
- Manually reproduced the overflow on `master` and confirmed both cases are
  fixed on this branch (see screenshots).

## Scope

Pure CSS addition to the shared base stylesheet - no theme currently
re-declares `svg`/`pre`/`code`, so this applies uniformly across every
style without any cascade conflicts.