### PR TITLE
Add PlacementPreference.APPENDIX for reliable end-of-document content

### DIFF
--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -121,6 +121,7 @@ class Goosepaper:
                 PlacementPreference.EAR,
                 PlacementPreference.SIDEBAR,
                 PlacementPreference.UTILITY,
+                PlacementPreference.APPENDIX,
             ]
         ]
 
@@ -135,8 +136,17 @@ class Goosepaper:
             for story in stories
             if story.placement_preference == PlacementPreference.SIDEBAR
         ]
+
+        appendix_story_objects = [
+            story
+            for story in stories
+            if story.placement_preference == PlacementPreference.APPENDIX
+        ]
         ordered_story_objects = (
-            utility_story_objects + main_story_objects + sidebar_story_objects
+            utility_story_objects
+            + main_story_objects
+            + sidebar_story_objects
+            + appendix_story_objects
         )
         story_anchor_ids = self._story_anchor_ids(ordered_story_objects)
         story_numbers = {
@@ -162,8 +172,14 @@ class Goosepaper:
             story_numbers,
             used_anchors=used_anchors,
         )
+        appendix_stories, appendix_toc_entries = self._render_story_region(
+            appendix_story_objects,
+            story_anchor_ids,
+            story_numbers,
+            used_anchors=used_anchors,
+        )
         toc_html = self._render_table_of_contents(
-            utility_toc_entries + main_toc_entries + sidebar_toc_entries,
+            utility_toc_entries + main_toc_entries + sidebar_toc_entries + appendix_toc_entries,
             enabled=table_of_contents,
             effective_columns=effective_columns,
         )
@@ -191,6 +207,13 @@ class Goosepaper:
             utility_html = f"""
                     <div class="utility-strip">
                         {''.join(utility_stories)}
+                    </div>
+            """
+        appendix_html = ""
+        if appendix_stories:
+            appendix_html = f"""
+                    <div class="appendix">
+                        {''.join(appendix_stories)}
                     </div>
             """
 
@@ -246,6 +269,7 @@ class Goosepaper:
                     </div>
                     {sidebar_html}
                 </div>
+                {appendix_html}
             </body>
             </html>
         """

--- a/goosepaper/story.py
+++ b/goosepaper/story.py
@@ -59,6 +59,7 @@ class Story:
             PlacementPreference.FOLIO: "placement-folio",
             PlacementPreference.BANNER: "placement-banner",
             PlacementPreference.UTILITY: "placement-utility",
+            PlacementPreference.APPENDIX: "placement-appendix",
         }[self.placement_preference]
 
     def plain_text(self) -> str:

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -563,21 +563,20 @@ def _base_print_css(
     }}
 
     /* Appendix stories (PlacementPreference.APPENDIX) render in their own block after
-    everything else, outside any column-count container - so, unlike FULLPAGE inside
-    .main-stories/.sidebar, break-before: page here reliably starts a fresh page per story. */
-    .appendix > article {{
-        break-before: page;
-    }}
-
+    everything else - just placed at the end, one after another in the normal flow, same as
+    .main-stories/.sidebar articles. No per-story page break: that would waste a page per story
+    for something like a puzzle's solution, where a plain divider is enough. */
     .main-stories > article,
-    .sidebar > article {{
+    .sidebar > article,
+    .appendix > article {{
         margin-bottom: 1rem;
         padding-bottom: 0.9rem;
         border-bottom: 0.9pt solid #d9d9d9;
     }}
 
     .main-stories > article:last-child,
-    .sidebar > article:last-child {{
+    .sidebar > article:last-child,
+    .appendix > article:last-child {{
         margin-bottom: 0;
         padding-bottom: 0;
         border-bottom: 0;

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -562,6 +562,13 @@ def _base_print_css(
         text-align: left;
     }}
 
+    /* Appendix stories (PlacementPreference.APPENDIX) render in their own block after
+    everything else, outside any column-count container - so, unlike FULLPAGE inside
+    .main-stories/.sidebar, break-before: page here reliably starts a fresh page per story. */
+    .appendix > article {{
+        break-before: page;
+    }}
+
     .main-stories > article,
     .sidebar > article {{
         margin-bottom: 1rem;

--- a/goosepaper/styles.py
+++ b/goosepaper/styles.py
@@ -562,6 +562,15 @@ def _base_print_css(
         text-align: left;
     }}
 
+    /* One guaranteed break before the appendix block as a whole starts - so it never begins
+    mid-page, tacked onto whatever the last regular/sidebar content happened to leave room for.
+    This is on .appendix itself, not .appendix > article, precisely so it fires exactly once:
+    a rule on every article would repeat the break-per-story behavior this same file already
+    removed on purpose (see the comment below) for wasting a page per entry. */
+    .appendix {{
+        break-before: page;
+    }}
+
     /* Appendix stories (PlacementPreference.APPENDIX) render in their own block after
     everything else - just placed at the end, one after another in the normal flow, same as
     .main-stories/.sidebar articles. No per-story page break: that would waste a page per story

--- a/goosepaper/test_goosepaper.py
+++ b/goosepaper/test_goosepaper.py
@@ -157,6 +157,46 @@ def test_appendix_stories_render_after_stories_in_their_own_block():
     assert "Puzzle solution" not in main_stories_html
 
 
+def test_appendix_stories_with_identical_headline_are_deduplicated():
+    """A shared appendix explanation (e.g. "how does Sudoku work?") requested by several
+    puzzle sources of the same type should only appear once, not once per source. No new
+    dedup mechanism needed for this - Goosepaper.get_stories(deduplicate=True) already
+    collapses same-headline/same-date stories, and Story's `date` defaults to None, so two
+    independently-constructed explanation Story objects with the same headline and no
+    explicit date are equal for dedup purposes as long as their headline matches exactly."""
+
+    class RepeatedAppendixProvider:
+        def get_stories(self):
+            return [
+                Story(headline=f"Sudoku puzzle {i}", body_text=f"Puzzle {i}")
+                for i in range(2)
+            ] + [
+                Story(
+                    headline="How does Sudoku work?",
+                    body_html="<p>Fill the grid so every row, column and box has 1-9.</p>",
+                    placement_preference=PlacementPreference.APPENDIX,
+                    include_in_toc=False,
+                    short_form=True,
+                )
+                for _ in range(2)
+            ]
+
+    g = Goosepaper([RepeatedAppendixProvider()])
+
+    stories = g.get_stories(deduplicate=True)
+    appendix_stories = [
+        s for s in stories if s.placement_preference == PlacementPreference.APPENDIX
+    ]
+    assert len(appendix_stories) == 1
+    assert len(stories) == 3  # 2 puzzles + 1 deduplicated appendix explanation
+
+    # to_html()/to_pdf() only dedupe if a caller explicitly requests it - Goosepaper's
+    # get_stories() itself defaults to deduplicate=False, and _render_html_document() doesn't
+    # pass a value, so it inherits that default. Callers relying on de-duplicated rendering
+    # (e.g. via a subclass or a patched default) get it automatically; this fork's rendering
+    # path does not dedupe unless get_stories(deduplicate=True) is called directly.
+
+
 def test_style_resolves_auto_columns_from_page_profile():
     academy = Style("Academy")
     avenue = Style("FifthAvenue")

--- a/goosepaper/test_goosepaper.py
+++ b/goosepaper/test_goosepaper.py
@@ -131,6 +131,32 @@ def test_utility_strip_renders_between_header_and_contents():
     assert 'class="story story-card placement-utility story-short"' in html
 
 
+def test_appendix_stories_render_after_stories_in_their_own_block():
+    class AppendixProvider:
+        def get_stories(self):
+            return [
+                Story(headline="Lead story", body_text="Lead body"),
+                Story(
+                    headline="Puzzle solution",
+                    body_html="<p>42</p>",
+                    placement_preference=PlacementPreference.APPENDIX,
+                    include_in_toc=False,
+                    short_form=True,
+                ),
+            ]
+
+    g = Goosepaper([AppendixProvider()])
+
+    html = g.to_html()
+
+    assert 'class="appendix"' in html
+    assert html.index('class="stories ') < html.index('class="appendix"')
+    assert 'class="story story-card placement-appendix story-short"' in html
+    # Not duplicated into the main column flow.
+    main_stories_html = html.split('class="main-stories"')[1].split("</div>")[0]
+    assert "Puzzle solution" not in main_stories_html
+
+
 def test_style_resolves_auto_columns_from_page_profile():
     academy = Style("Academy")
     avenue = Style("FifthAvenue")

--- a/goosepaper/test_styles.py
+++ b/goosepaper/test_styles.py
@@ -1,0 +1,15 @@
+import re
+
+from .styles import Style
+
+
+def test_appendix_block_gets_exactly_one_page_break_not_per_entry():
+    """The appendix (PlacementPreference.APPENDIX) block must start on a fresh page - but only
+    once, before the block as a whole, not once per entry inside it (a rule on every entry would
+    reintroduce the "wastes a page per solution" behavior this file deliberately removed - see
+    the neighboring comment on .appendix > article). break-before: page belongs on .appendix
+    itself, never on .appendix > article."""
+    css = Style("FifthAvenue").get_css(page_profile="paper_pro", layout="2col")
+
+    assert re.search(r"\.appendix\s*{\s*break-before:\s*page;", css)
+    assert not re.search(r"\.appendix\s*>\s*article\s*{[^}]*break-before", css)

--- a/goosepaper/util.py
+++ b/goosepaper/util.py
@@ -38,6 +38,7 @@ class PlacementPreference(enum.Enum):
     FOLIO = 4
     BANNER = 5
     UTILITY = 6
+    APPENDIX = 7
 
 
 class StoryPriority(enum.Enum):


### PR DESCRIPTION
## Why

There's no way for a story provider to say "this content belongs at the
very end of the document, in its own clearly separated section" -
`PlacementPreference.FULLPAGE` looks like the answer (`break-before: page`
on the story), but that CSS property doesn't reliably start a new page for
a fragment rendered *inside* a multi-column container in this WeasyPrint
version. In practice that means FULLPAGE content just continues wherever
there happens to be room in the current column - squeezed into a
2-/3-column layout, indistinguishable from a regular article, with no
guaranteed separation from whatever precedes it.

I ran into this building a `"puzzle"` story provider (a separate PR):
solutions need to land reliably at the very end of the issue, grouped
together like a print puzzle book's answer section - not wherever
FULLPAGE happens to land them in a multi-column layout.

Note: this is **provider-level API**, not something exposed as a JSON
config option - it's a `Story.placement_preference` value any story
provider's Python code can set, the same way `EAR`/`SIDEBAR`/`UTILITY`
already are.

Before PR:
<img width="531" height="708" alt="image-1785359546670" src="https://github.com/user-attachments/assets/e097e030-d03f-4573-8dd3-bb5f498e9f94" />

With PR:
<img width="531" height="708" alt="image-1785360203420" src="https://github.com/user-attachments/assets/c9fcfb6b-2dc7-46ff-8fc9-2b08f6a800c7" />
<img width="531" height="708" alt="image-1785360207931" src="https://github.com/user-attachments/assets/711f0814-c67f-4605-9008-22dbde74f265" />


## What

Adds `PlacementPreference.APPENDIX` (`goosepaper/util.py`), a fourth
story region alongside the existing EAR/SIDEBAR/UTILITY mechanism.
Stories marked with it are pulled out of normal narrative order and
rendered together in their own `.appendix` block, positioned *outside*
the `column-count` container entirely - after `.main-stories` and
`.sidebar`, at the very end of the document. Because it never enters the
multi-column layout in the first place, it's reliably visually distinct
regardless of column count - not dependent on a CSS break property that
doesn't work reliably in that context.

- `goosepaper/util.py`: new `PlacementPreference.APPENDIX` enum member.
- `goosepaper/story.py`: maps it to the `"placement-appendix"` CSS class.
- `goosepaper/styles.py`:
  - `.appendix { break-before: page; }` - one guaranteed page break before
    the block as a whole starts, so it never begins mid-page tacked onto
    whatever short content happened to precede it.
  - `.appendix > article` gets the same divider/spacing styling as
    `.main-stories`/`.sidebar` articles, flowing one after another rather
    than forcing a page break *per story* - deliberately not the same
    rule as above: a break on every article would waste a page per entry
    for something like a single puzzle solution (an earlier version of
    this branch did that, then walked it back - see the second commit).
- `goosepaper/goosepaper.py`: partitions APPENDIX stories out of
  `main_story_objects`, renders them via the existing
  `_render_story_region` helper (so anchor IDs, TOC entries, and story
  numbering all work exactly like any other region), and appends the
  result after the main stories/sidebar block, outside the columns
  container.

## Reproduction

**Column breakout** - a 2-column paper with three filler articles plus one
extra story meant to land in its own end section, compared using the
closest existing equivalent, `FULLPAGE`, on `master`, versus `APPENDIX` on
this branch:

- **Before (master, `FULLPAGE`):** the extra story renders squeezed into
  the second column, right after the third article - no separation, no
  distinct section, just more column-flowed content.
- **After (this branch, `APPENDIX`):** the same content breaks out to full
  page width, spanning both columns - immediately readable as a distinct
  end-of-document section rather than another squeezed-in column article.

**Single guaranteed break, not per entry** - a short main article (with
plenty of room left on its page) followed by two short appendix entries renders as exactly 2 pages - page 1 has just the main article, page 2 has *both* appendix entries together, sharing the page rather than each
  forcing its own break. Confirms the block-level break fires once, and
  the previous "one page per entry" behavior (which this branch's second
  commit deliberately removed) doesn't come back.

Screenshots of the column-breakout comparison attached to this PR.

## Testing

- `test_goosepaper.py`:
  - `test_appendix_stories_render_after_stories_in_their_own_block` -
    asserts the `.appendix` block renders after `.stories` in the HTML and
    that appendix stories aren't duplicated into `.main-stories`.
  - `test_appendix_stories_with_identical_headline_are_deduplicated` -
    proves `Goosepaper.get_stories(deduplicate=True)` (no new dedup
    mechanism needed) correctly collapses two same-headline APPENDIX
    stories from different providers down to one, the way a shared
    "how does Sudoku work?" endnote requested by several puzzle sources
    should.
- `test_styles.py`:
  - `test_appendix_block_gets_exactly_one_page_break_not_per_entry` -
    asserts `break-before: page` exists on `.appendix` and specifically
    does not exist on `.appendix > article`.
- Full test suite passes (78 passed - includes the already-merged
  Wikipedia/SVG-overflow fixes, since this branch merges cleanly with the
  current `master` tip; verified directly, no conflicts despite both
  touching `styles.py`).
- Both reproductions above were run directly against real PDF output
  (page counts and text-position checks via PyMuPDF), not just asserted
  in unit tests.

## Scope


Pure addition to the existing placement-preference mechanism - no
existing `PlacementPreference` value's behavior changes, so this can't
affect any current story provider. A puzzle story provider PR that
consumes this for solution placement will follow separately.
