### PR TITLE
fix: fall back to sniffed encoding when a page omits an explicit charset

### DIFF
--- a/goosepaper/storyprovider/rss.py
+++ b/goosepaper/storyprovider/rss.py
@@ -154,6 +154,13 @@ def _story_from_response(
     fallback_body_html: str = "",
     prefer_feed_title: bool = False,
 ) -> Story:
+    content_type = response.headers.get("content-type", "")
+    if "charset" not in content_type.lower():
+        # Per RFC 2616, requests defaults undeclared text/* charsets to
+        # ISO-8859-1, mangling UTF-8 pages that omit an explicit charset.
+        # Fall back to requests' own content-sniffed encoding instead.
+        response.encoding = response.apparent_encoding or response.encoding or "utf-8"
+
     page_text = response.text
     if not page_text:
         page_text = response.content.decode(

--- a/goosepaper/storyprovider/test_rss.py
+++ b/goosepaper/storyprovider/test_rss.py
@@ -36,16 +36,30 @@ class _FakeResponse:
         self,
         *,
         ok=True,
-        text="<html></html>",
+        text=None,
         content=b"<html></html>",
         encoding="utf-8",
         url="https://example.com/story",
+        apparent_encoding="utf-8",
+        headers=None,
     ):
         self.ok = ok
-        self.text = text
         self.content = content
         self.encoding = encoding
         self.url = url
+        self.apparent_encoding = apparent_encoding
+        self.headers = headers or {}
+        self._text_override = text
+
+    @property
+    def text(self):
+        # Mirrors requests.Response.text: decodes .content using whatever
+        # .encoding currently is, so tests can verify a fix that changes
+        # .encoding before .text is read. Tests that pass an explicit `text=`
+        # keep getting that fixed value unchanged.
+        if self._text_override is not None:
+            return self._text_override
+        return self.content.decode(self.encoding or "utf-8", errors="replace")
 
 
 def test_rss_provider_prefers_embedded_feed_content(monkeypatch):
@@ -596,6 +610,86 @@ def test_rss_provider_can_hide_all_bylines(monkeypatch):
 
     assert stories[0].byline is None
     assert stories[1].byline is None
+
+
+def test_rss_provider_falls_back_to_sniffed_encoding_when_charset_is_undeclared(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        rss.feedparser,
+        "parse",
+        lambda _: SimpleNamespace(entries=[_feed_entry(summary=None)]),
+    )
+    utf8_body = "<html><body>Über den Tellerrand</body></html>".encode("utf-8")
+    monkeypatch.setattr(
+        rss.requests,
+        "get",
+        lambda *args, **kwargs: _FakeResponse(
+            ok=True,
+            content=utf8_body,
+            encoding="ISO-8859-1",
+            apparent_encoding="utf-8",
+            headers={"content-type": "text/html"},
+        ),
+    )
+
+    seen = {}
+
+    class FakeDocument:
+        def __init__(self, html):
+            seen["html"] = html
+
+        def title(self):
+            return None
+
+        def summary(self):
+            return f"<p>{seen['html']}</p>"
+
+    monkeypatch.setattr(rss, "Document", FakeDocument)
+
+    provider = rss.RSSFeedStoryProvider("https://example.com/feed.xml")
+    provider.get_stories()
+
+    assert "Über den Tellerrand" in seen["html"]
+
+
+def test_rss_provider_respects_declared_charset(monkeypatch):
+    monkeypatch.setattr(
+        rss.feedparser,
+        "parse",
+        lambda _: SimpleNamespace(entries=[_feed_entry(summary=None)]),
+    )
+    latin1_body = "café".encode("ISO-8859-1")
+    monkeypatch.setattr(
+        rss.requests,
+        "get",
+        lambda *args, **kwargs: _FakeResponse(
+            ok=True,
+            content=latin1_body,
+            encoding="ISO-8859-1",
+            apparent_encoding="utf-8",  # would mis-decode if wrongly used instead
+            headers={"content-type": "text/html; charset=ISO-8859-1"},
+        ),
+    )
+
+    seen = {}
+
+    class FakeDocument:
+        def __init__(self, html):
+            seen["html"] = html
+
+        def title(self):
+            return None
+
+        def summary(self):
+            return f"<p>{seen['html']}</p>"
+
+    monkeypatch.setattr(rss, "Document", FakeDocument)
+
+    provider = rss.RSSFeedStoryProvider("https://example.com/feed.xml")
+    provider.get_stories()
+
+    assert seen["html"] == "café"
 
 
 def test_rss_provider_can_show_only_first_byline(monkeypatch):


### PR DESCRIPTION
## Summary
- `requests` defaults undeclared `text/*` charsets to ISO-8859-1 per RFC 2616. When a fetched article page's `Content-Type` header doesn't declare a charset, this mangles UTF-8 pages (accented characters etc. get decoded as the wrong encoding).
- Fall back to `response.apparent_encoding` (requests' own content-sniffing) in that case, before the body is read - so `_story_from_response` sees correctly decoded text.
- No behavior change for pages that do declare a charset in their header.

## Test plan
- [x] `pytest goosepaper/storyprovider/test_rss.py` - 11 passed (9 existing + 2 new: an undeclared charset gets sniffed and decoded correctly; a declared charset is left untouched, even when sniffing would've suggested something different)
- [x] Full suite (`pytest`) - 80 passed

## Merge overlap note

Verified by locally merging every pairwise combination of my currently open PRs against `master`. This one produces a mechanical (non-semantic) merge conflict with **#121, #128, #135** - all touch `rss.py`/`test_rss.py` at nearby insertion points. No logic overlap in any case checked.
