### PR TITLE
feat: optionally prefer the feed's own title over readability's extracted title

### DIFF
--- a/goosepaper/storyprovider/rss.py
+++ b/goosepaper/storyprovider/rss.py
@@ -22,6 +22,7 @@ class RSSFeedStoryProvider(StoryProvider):
         since_days_ago: int = None,
         byline: str = "all",
         body_source: str = "auto",
+        prefer_feed_title: bool = False,
     ) -> None:
         if byline not in RSS_BYLINE_MODES:
             raise ValueError(
@@ -36,6 +37,7 @@ class RSSFeedStoryProvider(StoryProvider):
         self.feed_url = rss_path
         self.byline_mode = byline
         self.body_source = body_source
+        self.prefer_feed_title = prefer_feed_title
         self._since = (
             datetime.datetime.now() - datetime.timedelta(days=since_days_ago)
             if since_days_ago
@@ -60,6 +62,7 @@ class RSSFeedStoryProvider(StoryProvider):
                 source,
                 date,
                 body_source=self.body_source,
+                prefer_feed_title=self.prefer_feed_title,
             )
 
             if story is None:
@@ -81,6 +84,7 @@ def _story_from_entry(
     source: str,
     date: datetime.datetime,
     body_source: str = "auto",
+    prefer_feed_title: bool = False,
 ) -> Optional[Story]:
     if body_source == "summary":
         return Story(
@@ -136,6 +140,7 @@ def _story_from_entry(
         source,
         date,
         fallback_body_html=fallback_body_html,
+        prefer_feed_title=prefer_feed_title,
     )
 
 
@@ -145,6 +150,7 @@ def _story_from_response(
     source: str,
     date: datetime.datetime,
     fallback_body_html: str = "",
+    prefer_feed_title: bool = False,
 ) -> Story:
     page_text = response.text
     if not page_text:
@@ -155,7 +161,10 @@ def _story_from_response(
 
     try:
         doc = Document(page_text)
-        headline = doc.title() or entry["title"]
+        # readability's own title extraction is unreliable on some sites (e.g. it
+        # returns just the site name for every article on some blogs); the feed's
+        # own <title> is usually accurate, so let callers prefer it outright.
+        headline = entry["title"] if prefer_feed_title else (doc.title() or entry["title"])
         body_html = doc.summary() or fallback_body_html
     except Exception:
         headline = entry["title"]

--- a/goosepaper/storyprovider/test_rss.py
+++ b/goosepaper/storyprovider/test_rss.py
@@ -202,6 +202,67 @@ def test_rss_provider_passes_text_to_readability(monkeypatch):
     assert stories[0].body_html == "<p>Readable summary</p>"
 
 
+def test_rss_provider_prefer_feed_title_overrides_readability_title(monkeypatch):
+    class FakeDocument:
+        def __init__(self, html):
+            pass
+
+        def title(self):
+            return "Golem.de"  # e.g. readability returning just the site name
+
+        def summary(self):
+            return "<p>Readable summary</p>"
+
+    monkeypatch.setattr(
+        rss.feedparser,
+        "parse",
+        lambda _: SimpleNamespace(entries=[_feed_entry(title="The actual headline", summary=None)]),
+    )
+    monkeypatch.setattr(
+        rss.requests,
+        "get",
+        lambda *args, **kwargs: _FakeResponse(ok=True, text="<html></html>"),
+    )
+    monkeypatch.setattr(rss, "Document", FakeDocument)
+
+    provider = rss.RSSFeedStoryProvider(
+        "https://example.com/feed.xml",
+        prefer_feed_title=True,
+    )
+    stories = provider.get_stories()
+
+    assert stories[0].headline == "The actual headline"
+
+
+def test_rss_provider_prefer_feed_title_defaults_to_false(monkeypatch):
+    class FakeDocument:
+        def __init__(self, html):
+            pass
+
+        def title(self):
+            return "Readable title"
+
+        def summary(self):
+            return "<p>Readable summary</p>"
+
+    monkeypatch.setattr(
+        rss.feedparser,
+        "parse",
+        lambda _: SimpleNamespace(entries=[_feed_entry(summary=None)]),
+    )
+    monkeypatch.setattr(
+        rss.requests,
+        "get",
+        lambda *args, **kwargs: _FakeResponse(ok=True, text="<html></html>"),
+    )
+    monkeypatch.setattr(rss, "Document", FakeDocument)
+
+    provider = rss.RSSFeedStoryProvider("https://example.com/feed.xml")
+    stories = provider.get_stories()
+
+    assert stories[0].headline == "Readable title"
+
+
 def test_rss_provider_article_mode_fetches_article_even_when_feed_has_content(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- readability's `doc.title()` is unreliable on some sites (e.g. it returns just the site name for every article on some blogs). The RSS feed's own `<title>` is usually accurate.
- New `prefer_feed_title` flag, off by default so existing behavior is unchanged; callers who hit this on a specific feed can opt in per source.

## Test plan
- [x] `pytest goosepaper/storyprovider/test_rss.py` - 11 passed (9 existing + 2 new: flag on -> feed title wins; flag off/default -> readability title unchanged)
- [x] Full suite (`pytest`) - 80 passed

## Merge overlap note

Verified by locally merging every pairwise combination of my currently open PRs against `master`. This one produces a mechanical (non-semantic) merge conflict with **#121** only - both add new parameters to `RSSFeedStoryProvider.__init__` at the same point. No overlap with any other currently open PR.
