### PR TITLE
fix: actually expose the existing deduplicate option to callers

### DIFF
--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -37,6 +37,7 @@ class Goosepaper:
         story_providers: List[StoryProvider],
         title: str = None,
         subtitle: str = None,
+        deduplicate: bool = False,
     ):
         """
         Create a new Goosepaper.
@@ -45,24 +46,30 @@ class Goosepaper:
             story_providers: A list of StoryProvider objects to render
             title: The title of the goosepaper
             subtitle: The subtitle of the goosepaper
+            deduplicate: Whether to remove stories with a matching headline and date when
+                rendering. Default: False
 
         """
         self.story_providers = story_providers
         self.title = title if title else "Daily Goosepaper"
         self.subtitle = subtitle + "\n" if subtitle else ""
         self.subtitle += datetime.datetime.today().strftime("%B %d, %Y %H:%M")
+        self.deduplicate = deduplicate
 
-    def get_stories(self, deduplicate: bool = False) -> List[Story]:
+    def get_stories(self, deduplicate: bool = None) -> List[Story]:
         """
         Retrieve the complete list of stories to render in this Goosepaper.
 
         Arguments:
-            deduplicate: Whether to remove duplicate stories. Default: False
+            deduplicate: Whether to remove duplicate stories. Defaults to the value passed to
+                the constructor.
 
         Returns:
             List[Story]
 
         """
+        if deduplicate is None:
+            deduplicate = self.deduplicate
         stories: List[Story] = []
         for prov in self.story_providers:
             try:

--- a/goosepaper/test_goosepaper.py
+++ b/goosepaper/test_goosepaper.py
@@ -190,11 +190,21 @@ def test_appendix_stories_with_identical_headline_are_deduplicated():
     assert len(appendix_stories) == 1
     assert len(stories) == 3  # 2 puzzles + 1 deduplicated appendix explanation
 
-    # to_html()/to_pdf() only dedupe if a caller explicitly requests it - Goosepaper's
-    # get_stories() itself defaults to deduplicate=False, and _render_html_document() doesn't
-    # pass a value, so it inherits that default. Callers relying on de-duplicated rendering
-    # (e.g. via a subclass or a patched default) get it automatically; this fork's rendering
-    # path does not dedupe unless get_stories(deduplicate=True) is called directly.
+    # to_html()/to_pdf() only dedupe if a caller explicitly requests it. get_stories() defaults
+    # to deduplicate=None, which falls back to the Goosepaper instance's own `deduplicate`
+    # constructor argument (default False) - see test_to_html_* below for that path.
+
+
+def test_to_html_deduplicates_when_constructor_flag_is_set():
+    g = Goosepaper([LoremStoryProvider(limit=3)], deduplicate=True)
+    html = g.to_html()
+    assert html.count("Lorem Ipsum Dolor Sit Amet") == 1
+
+
+def test_to_html_does_not_deduplicate_by_default():
+    g = Goosepaper([LoremStoryProvider(limit=3)])
+    html = g.to_html()
+    assert html.count("Lorem Ipsum Dolor Sit Amet") == 3
 
 
 def test_style_resolves_auto_columns_from_page_profile():


### PR DESCRIPTION
## Summary
- `Goosepaper.get_stories(deduplicate=...)` already existed, but nothing else ever passed a value through: `_render_html_document()` (used by both `to_html()` and `to_pdf()`) calls `self.get_stories()` with no arguments, so the option was unreachable except by calling `get_stories()` directly.
- Add a `deduplicate` constructor argument that `get_stories()` now falls back to when its own parameter is omitted, so `to_html()`/`to_pdf()` honor it too.
- Default unchanged (`False`), so existing behavior is untouched unless a caller opts in.

## Why this matters beyond this PR

This closes a gap that #124 (puzzle-explanations) currently has: #124's `"footer"`/`"appendix"` explanation modes rely on `Goosepaper.get_stories(deduplicate=True)` to collapse a rules blurb requested by several sources of the same puzzle type down to one copy. #124's own tests call `get_stories(deduplicate=True)` directly to verify this, but neither `goosepaper/__main__.py` nor `to_html()`/`to_pdf()` pass `deduplicate=True` through today - so a real user generating a paper via the CLI/Docker wouldn't actually get that dedup behavior, only a caller that bypasses `to_html()`/`to_pdf()` and calls `get_stories()` directly would. This PR is what makes that dedup reachable from a real render, e.g. `Goosepaper(providers, deduplicate=True).to_pdf(...)`.

## Test plan
- [x] `pytest goosepaper/test_goosepaper.py` - 15 passed (13 existing + 2 new: `to_html()` deduplicates when the constructor flag is set; doesn't by default)
- [x] Full suite (`pytest`) - 80 passed