### PR TITLE
feat: clean two-level PDF outline (sections/headlines) by default, configurable

### DIFF
--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -25,6 +25,25 @@ def _get_style(style):
     return style_obj
 
 
+def _bookmark_css(
+    *,
+    section_bookmark_level: Optional[int],
+    headline_bookmark_level: Optional[int],
+    body_heading_bookmarks: bool,
+) -> str:
+    rules = []
+    if section_bookmark_level is not None:
+        rules.append(f"h2.story-section-title {{ bookmark-level: {section_bookmark_level}; }}")
+    if headline_bookmark_level is not None:
+        rules.append(f"h1.story-headline {{ bookmark-level: {headline_bookmark_level}; }}")
+    if not body_heading_bookmarks:
+        rules.append(
+            ".story-body h1, .story-body h2, .story-body h3, "
+            ".story-body h4, .story-body h5, .story-body h6 { bookmark-level: none; }"
+        )
+    return "\n".join(rules)
+
+
 class Goosepaper:
     """
     A high-level class that manages the creation and styling of a goosepaper
@@ -316,6 +335,9 @@ class Goosepaper:
         table_of_contents: bool = False,
         layout: str = "auto",
         page_profile: str = "remarkable2",
+        section_bookmark_level: Optional[int] = 1,
+        headline_bookmark_level: Optional[int] = 2,
+        body_heading_bookmarks: bool = False,
     ) -> Optional[str]:
         """
         Renders the current Goosepaper to a PDF file on disk.
@@ -326,6 +348,18 @@ class Goosepaper:
                 function will return None.
             style: The style to use for the paper. Default: FifthAvenueStyle
             font_size: The font size to use for the paper. Default: 14
+            section_bookmark_level: PDF outline (bookmark) level for section headings, or None
+                to leave WeasyPrint's default (one bookmark per heading tag) untouched.
+                Default: 1
+            headline_bookmark_level: PDF outline level for story headlines, or None to leave
+                WeasyPrint's default untouched. Default: 2
+            body_heading_bookmarks: Whether headings inside a story's own body content (e.g. an
+                article's preserved subheadings) should appear in the PDF outline at all.
+                Default: False - WeasyPrint's default UA stylesheet turns every <h1>-<h6> into a
+                bookmark matching its tag, which - combined with section headings rendering as
+                <h2> and story headlines as <h1> - produces a flat, cluttered outline where
+                incidental subheadings from a story's own source markup sit at the same level as
+                section and story titles.
 
         Returns:
             str: The filename of the PDF file. If `filename` is an IO object,
@@ -358,10 +392,20 @@ class Goosepaper:
             font_config=font_config,
             base_url=base_url,
         )
+        bookmark_stylesheets = []
+        bookmark_css_text = _bookmark_css(
+            section_bookmark_level=section_bookmark_level,
+            headline_bookmark_level=headline_bookmark_level,
+            body_heading_bookmarks=body_heading_bookmarks,
+        )
+        if bookmark_css_text:
+            bookmark_stylesheets.append(
+                CSS(string=bookmark_css_text, font_config=font_config, base_url=base_url)
+            )
         if isinstance(filename, str):
             h.write_pdf(
                 filename,
-                stylesheets=[c, *style_obj.get_stylesheets()],
+                stylesheets=[c, *bookmark_stylesheets, *style_obj.get_stylesheets()],
                 font_config=font_config,
             )
             return filename
@@ -369,7 +413,7 @@ class Goosepaper:
             tf = tempfile.NamedTemporaryFile(suffix=".pdf")
             h.write_pdf(
                 tf,
-                stylesheets=[c, *style_obj.get_stylesheets()],
+                stylesheets=[c, *bookmark_stylesheets, *style_obj.get_stylesheets()],
             )
             tf.seek(0)
             filename.write(tf.read())

--- a/goosepaper/goosepaper.py
+++ b/goosepaper/goosepaper.py
@@ -3,6 +3,7 @@ import io
 import pathlib
 import re
 import tempfile
+import warnings
 from html import escape
 from typing import List, Optional, Type, Union
 from uuid import uuid4
@@ -31,11 +32,25 @@ def _bookmark_css(
     headline_bookmark_level: Optional[int],
     body_heading_bookmarks: bool,
 ) -> str:
+    if (
+        section_bookmark_level is not None
+        and section_bookmark_level == headline_bookmark_level
+    ):
+        warnings.warn(
+            "section_bookmark_level and headline_bookmark_level are both "
+            f"{section_bookmark_level}; sections and story headlines will sit at the same "
+            "depth in the PDF outline instead of headlines nesting under sections.",
+            stacklevel=2,
+        )
     rules = []
     if section_bookmark_level is not None:
-        rules.append(f"h2.story-section-title {{ bookmark-level: {section_bookmark_level}; }}")
+        rules.append(f".story-section-title {{ bookmark-level: {section_bookmark_level}; }}")
+        # The masthead title isn't itself a section, but nothing else claims a bookmark
+        # level for it - anchor it explicitly to the section level rather than leaving it
+        # to whatever level WeasyPrint's UA stylesheet happens to assign a bare <h1>.
+        rules.append(f".masthead h1 {{ bookmark-level: {section_bookmark_level}; }}")
     if headline_bookmark_level is not None:
-        rules.append(f"h1.story-headline {{ bookmark-level: {headline_bookmark_level}; }}")
+        rules.append(f".story-headline {{ bookmark-level: {headline_bookmark_level}; }}")
     if not body_heading_bookmarks:
         rules.append(
             ".story-body h1, .story-body h2, .story-body h3, "
@@ -348,11 +363,15 @@ class Goosepaper:
                 function will return None.
             style: The style to use for the paper. Default: FifthAvenueStyle
             font_size: The font size to use for the paper. Default: 14
-            section_bookmark_level: PDF outline (bookmark) level for section headings, or None
-                to leave WeasyPrint's default (one bookmark per heading tag) untouched.
-                Default: 1
+            section_bookmark_level: PDF outline (bookmark) level for section headings and the
+                paper's own masthead title, or None to leave WeasyPrint's default (one bookmark
+                per heading tag) untouched. Default: 1
             headline_bookmark_level: PDF outline level for story headlines, or None to leave
-                WeasyPrint's default untouched. Default: 2
+                WeasyPrint's default untouched. Note that "untouched" is WeasyPrint's raw
+                per-tag default (h1 -> level 1), which can numerically coincide with
+                section_bookmark_level and collapse the two-level hierarchy just as if you'd
+                set both levels to the same number - it does not guarantee headlines stay
+                independent of the configured section level. Default: 2
             body_heading_bookmarks: Whether headings inside a story's own body content (e.g. an
                 article's preserved subheadings) should appear in the PDF outline at all.
                 Default: False - WeasyPrint's default UA stylesheet turns every <h1>-<h6> into a

--- a/goosepaper/test_goosepaper.py
+++ b/goosepaper/test_goosepaper.py
@@ -1,3 +1,7 @@
+import warnings
+
+import pytest
+
 from .goosepaper import Goosepaper, _bookmark_css
 from .story import Story
 from .styles import Style
@@ -240,10 +244,33 @@ def test_bookmark_css_uses_the_given_levels_by_default():
         body_heading_bookmarks=False,
     )
 
-    assert "h2.story-section-title { bookmark-level: 1; }" in css
-    assert "h1.story-headline { bookmark-level: 2; }" in css
+    assert ".story-section-title { bookmark-level: 1; }" in css
+    assert ".story-headline { bookmark-level: 2; }" in css
     assert ".story-body h1" in css
     assert "bookmark-level: none" in css
+
+
+def test_bookmark_css_selectors_are_class_only_not_tag_coupled():
+    # story-headline is rendered with a caller-configurable tag (Story.to_html's
+    # headline_tag), so the rule must match on class alone rather than assuming <h1>.
+    css = _bookmark_css(
+        section_bookmark_level=1,
+        headline_bookmark_level=2,
+        body_heading_bookmarks=False,
+    )
+
+    assert "h1.story-headline" not in css
+    assert "h2.story-section-title" not in css
+
+
+def test_bookmark_css_anchors_the_masthead_title_to_the_section_level():
+    css = _bookmark_css(
+        section_bookmark_level=1,
+        headline_bookmark_level=2,
+        body_heading_bookmarks=False,
+    )
+
+    assert ".masthead h1 { bookmark-level: 1; }" in css
 
 
 def test_bookmark_css_omits_a_rule_when_its_level_is_none():
@@ -254,7 +281,8 @@ def test_bookmark_css_omits_a_rule_when_its_level_is_none():
     )
 
     assert "story-section-title" not in css
-    assert "h1.story-headline { bookmark-level: 2; }" in css
+    assert ".masthead h1" not in css
+    assert ".story-headline { bookmark-level: 2; }" in css
 
 
 def test_bookmark_css_keeps_body_heading_bookmarks_when_enabled():
@@ -275,3 +303,30 @@ def test_bookmark_css_is_empty_when_everything_is_disabled():
     )
 
     assert css == ""
+
+
+def test_bookmark_css_warns_when_section_and_headline_levels_collide():
+    with pytest.warns(UserWarning, match="same depth"):
+        css = _bookmark_css(
+            section_bookmark_level=1,
+            headline_bookmark_level=1,
+            body_heading_bookmarks=False,
+        )
+
+    assert ".story-section-title { bookmark-level: 1; }" in css
+    assert ".story-headline { bookmark-level: 1; }" in css
+
+
+def test_bookmark_css_does_not_warn_when_levels_differ_or_are_none():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _bookmark_css(
+            section_bookmark_level=1,
+            headline_bookmark_level=2,
+            body_heading_bookmarks=False,
+        )
+        _bookmark_css(
+            section_bookmark_level=None,
+            headline_bookmark_level=None,
+            body_heading_bookmarks=False,
+        )

--- a/goosepaper/test_goosepaper.py
+++ b/goosepaper/test_goosepaper.py
@@ -1,4 +1,4 @@
-from .goosepaper import Goosepaper
+from .goosepaper import Goosepaper, _bookmark_css
 from .story import Story
 from .styles import Style
 from .util import PlacementPreference
@@ -231,3 +231,47 @@ def test_graymaiden_style_loads_editorial_masthead_assets():
     assert "target-counter(attr(href), page)" in css
     assert "UnifrakturCook" not in css
     assert style.get_stylesheets()
+
+
+def test_bookmark_css_uses_the_given_levels_by_default():
+    css = _bookmark_css(
+        section_bookmark_level=1,
+        headline_bookmark_level=2,
+        body_heading_bookmarks=False,
+    )
+
+    assert "h2.story-section-title { bookmark-level: 1; }" in css
+    assert "h1.story-headline { bookmark-level: 2; }" in css
+    assert ".story-body h1" in css
+    assert "bookmark-level: none" in css
+
+
+def test_bookmark_css_omits_a_rule_when_its_level_is_none():
+    css = _bookmark_css(
+        section_bookmark_level=None,
+        headline_bookmark_level=2,
+        body_heading_bookmarks=False,
+    )
+
+    assert "story-section-title" not in css
+    assert "h1.story-headline { bookmark-level: 2; }" in css
+
+
+def test_bookmark_css_keeps_body_heading_bookmarks_when_enabled():
+    css = _bookmark_css(
+        section_bookmark_level=1,
+        headline_bookmark_level=2,
+        body_heading_bookmarks=True,
+    )
+
+    assert ".story-body" not in css
+
+
+def test_bookmark_css_is_empty_when_everything_is_disabled():
+    css = _bookmark_css(
+        section_bookmark_level=None,
+        headline_bookmark_level=None,
+        body_heading_bookmarks=True,
+    )
+
+    assert css == ""


### PR DESCRIPTION
## Summary
- WeasyPrint's default UA stylesheet turns every `<h1>`-`<h6>` into a PDF bookmark matching its tag, which - combined with section headings rendering as `<h2>` and story headlines as `<h1>` - produced a flat, cluttered outline where a story's own incidental subheadings (e.g. an article's preserved "Pros"/"Cons" subheadings from its source markup) sat alongside section and story titles.
- `to_pdf()` now generates the bookmark-level CSS itself from three parameters (`section_bookmark_level=1`, `headline_bookmark_level=2`, `body_heading_bookmarks=False` by default) instead of requiring callers to ship their own stylesheet for it. Pass `None` for either level to leave WeasyPrint's default behavior untouched, or `body_heading_bookmarks=True` to keep in-body headings in the outline.

## Why this matters
A clean, two-level outline is what lets you actually navigate a document on a reMarkable: tap the page-overview/outline button and jump straight to a section or story, no scrolling. That matters most exactly when a paper combines many different sources into one long document - a handful of RSS feeds, Wikipedia, weather, puzzles, whatever - where without this, the outline is either flooded with noise from every incidental heading inside fetched article bodies, or (on plain WeasyPrint defaults) just unusably flat. The outline stays available from anywhere in the document, regardless of how deep you've scrolled - not just at the top.

## Follow-up fixes (second commit)
A closer review of `_bookmark_css()` surfaced three sharp edges, all fixed in the second commit:
- **Selectors were coupled to a heading tag that's actually variable.** The rule matched `h1.story-headline`, but `Story.to_html()` takes `headline_tag` as a parameter (default `"h1"`, currently unused elsewhere but live). If a future caller ever renders a headline as e.g. `<h2>` (say, for ear stories), the bookmark rule would silently stop matching and that headline would fall back to WeasyPrint's raw per-tag default. Selectors are now class-only (`.story-headline`, `.story-section-title`), independent of the tag.
- **The masthead title was never covered by `_bookmark_css()` at all.** It's a bare `<h1>` with no `.story-headline` class, so it only ever landed at the "right" outline level by coincidence - WeasyPrint's UA default for `<h1>` happens to equal the default `section_bookmark_level` of `1`. It's now explicitly anchored to `section_bookmark_level`, so that relationship survives someone changing that parameter later instead of silently drifting.
- **Setting `section_bookmark_level` and `headline_bookmark_level` to the same value collapses the whole point of the feature** (a two-level outline) with no signal that anything went wrong. `_bookmark_css()` now emits a `UserWarning` when this happens, and the docstring calls out that `headline_bookmark_level=None` can numerically coincide with `section_bookmark_level` for the same reason (both resolving to WeasyPrint's raw level for their tag).

## Test plan
- [x] `pytest goosepaper/test_goosepaper.py` - 21 passed, including 8 covering `_bookmark_css()`: default levels, class-only selectors, the masthead rule, a level set to `None`, `body_heading_bookmarks=True`, everything disabled, and the new same-level warning (both that it fires and that it doesn't fire for independent/`None` levels)
- [x] Full suite (`pytest`) - 86 passed
- [x] End-to-end verification with a real WeasyPrint render (not just the string-generation unit tests): built a fixture paper with two sections, four stories, and bodies containing their own subheadings (`Pros`/`Cons`, `Ingredients`/`Steps`, etc. - the exact scenario this PR targets), rendered it to PDF across 5 bookmark configurations, and inspected the actual PDF outline tree with `pypdf`. Confirms the default config produces a clean two-level outline with body subheadings fully excluded, and that the previously-undetected `headline_bookmark_level=None` / `section_bookmark_level` collision produced an identical flat outline to explicitly setting both to `1` - the exact issue the second commit's warning now surfaces.
  - (WeasyPrint needs its native Pango/GObject libs on the loader path to run at all - on macOS with Homebrew that's `DYLD_LIBRARY_PATH=/opt/homebrew/lib`; CI images with those system packages installed can run this directly.)
