### PR TITLE
feat: add retention_keep_last_n/retention_prefix delivery settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,15 +149,19 @@ Delivery still happens only when you pass `--deliver`. If you want user-level de
     "delivery_defaults": {
         "folder": "News",
         "replace_mode": "nocase",
-        "cleanup": true
+        "cleanup": true,
+        "retention_keep_last_n": 7,
+        "retention_prefix": "Daily Goose "
     }
 }
 ```
 
+`retention_keep_last_n`/`retention_prefix` prune older deliveries after a successful upload - once you're on a schedule (a cron job invoking `goosepaper --deliver` daily), your reMarkable's `folder` otherwise accumulates one document per run forever. Every document in `folder` whose name starts with `retention_prefix` is a candidate; only the most recent `retention_keep_last_n` (by name, so a `YYYY-MM-DD`-suffixed name like `"Daily Goose 2026-08-05"` sorts correctly) survive, and anything not matching the prefix - a different paper sharing the same folder - is left alone. Both settings must be given together; neither has a default, so retention is off unless you opt in.
+
 CLI flags override the config for a single run:
 
 ```shell
-uv run goosepaper --deliver --folder Inbox --replace-mode exact
+uv run goosepaper --deliver --folder Inbox --replace-mode exact --retention-keep-last-n 7 --retention-prefix "Daily Goose "
 ```
 
 An example config file is included here: [example-config.json](example-config.json).

--- a/goosepaper/config.py
+++ b/goosepaper/config.py
@@ -92,6 +92,13 @@ class DeliverySettings:
     folder: Optional[str] = None
     replace_mode: str = "never"
     cleanup: bool = False
+    # Retention prunes *other* documents in `folder` from a previous delivery - distinct from
+    # `cleanup`, which only ever touches the local file just uploaded. Both must be set together:
+    # keep_last_n has nothing to match past editions against without a prefix, and a prefix with
+    # no count wouldn't know how many to keep. Off (None/None) by default - existing callers see
+    # no behavior change. See upload()'s own docstring for what "match" means.
+    retention_keep_last_n: Optional[int] = None
+    retention_prefix: Optional[str] = None
 
     def __post_init__(self):
         _validate_folder(self.folder, "delivery folder")
@@ -103,12 +110,28 @@ class DeliverySettings:
             )
         if not isinstance(self.cleanup, bool):
             raise ValueError("cleanup must be a boolean.")
+        if self.retention_keep_last_n is not None and (
+            not isinstance(self.retention_keep_last_n, int)
+            or isinstance(self.retention_keep_last_n, bool)
+            or self.retention_keep_last_n <= 0
+        ):
+            raise ValueError("retention_keep_last_n must be a positive integer or null.")
+        if self.retention_prefix is not None and (
+            not isinstance(self.retention_prefix, str) or not self.retention_prefix
+        ):
+            raise ValueError("retention_prefix must be a non-empty string or null.")
+        if self.retention_keep_last_n is not None and self.retention_prefix is None:
+            raise ValueError("retention_keep_last_n requires retention_prefix to also be set.")
+        if self.retention_prefix is not None and self.retention_keep_last_n is None:
+            raise ValueError("retention_prefix requires retention_keep_last_n to also be set.")
 
     def to_dict(self) -> Dict[str, Any]:
         return {
             "folder": self.folder,
             "replace_mode": self.replace_mode,
             "cleanup": self.cleanup,
+            "retention_keep_last_n": self.retention_keep_last_n,
+            "retention_prefix": self.retention_prefix,
         }
 
 
@@ -234,6 +257,21 @@ def build_cli_parser() -> argparse.ArgumentParser:
         help="Keep the output file after delivery, even if user defaults say otherwise.",
     )
     parser.add_argument(
+        "--retention-keep-last-n",
+        type=int,
+        required=False,
+        help='Keep only the last N delivered documents whose name starts with '
+        '"--retention-prefix" in the delivery folder, deleting older ones. Requires '
+        '"--retention-prefix".',
+    )
+    parser.add_argument(
+        "--retention-prefix",
+        required=False,
+        help='The name prefix "--retention-keep-last-n" matches past editions against '
+        '(e.g. "Daily Goose " for documents named "Daily Goose 2026-08-05"). Requires '
+        '"--retention-keep-last-n".',
+    )
+    parser.add_argument(
         "-n",
         "--nostory",
         required=False,
@@ -309,7 +347,8 @@ def resolve_runtime_config(args: Optional[Sequence[str]] = None) -> ResolvedConf
     if not cli_args.deliver and _has_delivery_cli_overrides(cli_args):
         raise ConfigError(
             "Delivery override flags require '--deliver'. "
-            "Run goosepaper with '--deliver' to use '--folder', '--replace-mode', or cleanup overrides."
+            "Run goosepaper with '--deliver' to use '--folder', '--replace-mode', cleanup, or "
+            "retention overrides."
         )
 
     if cli_args.nostory and not cli_args.deliver:
@@ -348,6 +387,8 @@ def resolve_runtime_config(args: Optional[Sequence[str]] = None) -> ResolvedConf
             folder_override=cli_args.folder,
             replace_mode_override=cli_args.replace_mode,
             cleanup_override=cli_args.cleanup,
+            retention_keep_last_n_override=cli_args.retention_keep_last_n,
+            retention_prefix_override=cli_args.retention_prefix,
         ),
         output=cli_args.output or default_output_filename(),
         deliver=cli_args.deliver,
@@ -364,6 +405,8 @@ def resolve_delivery_settings(
     folder_override: Optional[str] = None,
     replace_mode_override: Optional[str] = None,
     cleanup_override: Optional[bool] = None,
+    retention_keep_last_n_override: Optional[int] = None,
+    retention_prefix_override: Optional[str] = None,
 ) -> DeliverySettings:
     user_defaults = user_defaults or DeliverySettings()
     paper_delivery = paper_delivery or DeliveryIntent()
@@ -382,6 +425,16 @@ def resolve_delivery_settings(
             cleanup=user_defaults.cleanup
             if cleanup_override is None
             else cleanup_override,
+            retention_keep_last_n=(
+                retention_keep_last_n_override
+                if retention_keep_last_n_override is not None
+                else user_defaults.retention_keep_last_n
+            ),
+            retention_prefix=(
+                retention_prefix_override
+                if retention_prefix_override is not None
+                else user_defaults.retention_prefix
+            ),
         )
     except ValueError as err:
         raise ConfigError(str(err)) from err
@@ -521,7 +574,11 @@ def _parse_delivery_intent(raw: Any) -> DeliveryIntent:
 
 def _parse_delivery_settings(raw: Any, context: str) -> DeliverySettings:
     section = _require_object(raw, context)
-    _reject_unknown_keys(section, {"folder", "replace_mode", "cleanup"}, context)
+    _reject_unknown_keys(
+        section,
+        {"folder", "replace_mode", "cleanup", "retention_keep_last_n", "retention_prefix"},
+        context,
+    )
 
     replace_mode = section.get("replace_mode", DeliverySettings.replace_mode)
     cleanup = section.get("cleanup", DeliverySettings.cleanup)
@@ -530,6 +587,8 @@ def _parse_delivery_settings(raw: Any, context: str) -> DeliverySettings:
         folder=section.get("folder"),
         replace_mode=replace_mode,
         cleanup=cleanup,
+        retention_keep_last_n=section.get("retention_keep_last_n"),
+        retention_prefix=section.get("retention_prefix"),
     )
 
 
@@ -837,5 +896,7 @@ def _has_delivery_cli_overrides(cli_args: argparse.Namespace) -> bool:
             cli_args.folder is not None,
             cli_args.replace_mode is not None,
             cli_args.cleanup is not None,
+            cli_args.retention_keep_last_n is not None,
+            cli_args.retention_prefix is not None,
         ]
     )

--- a/goosepaper/test_config.py
+++ b/goosepaper/test_config.py
@@ -132,6 +132,71 @@ def test_resolve_delivery_settings_paper_folder_overrides_user_default():
     assert delivery.folder == "Morning Brief"
 
 
+def test_delivery_settings_rejects_retention_keep_last_n_without_prefix():
+    try:
+        DeliverySettings(retention_keep_last_n=3)
+    except ValueError as err:
+        assert "retention_keep_last_n requires retention_prefix" in str(err)
+    else:
+        assert False, "Expected ValueError"
+
+
+def test_delivery_settings_rejects_retention_prefix_without_keep_last_n():
+    try:
+        DeliverySettings(retention_prefix="Daily Goose ")
+    except ValueError as err:
+        assert "retention_prefix requires retention_keep_last_n" in str(err)
+    else:
+        assert False, "Expected ValueError"
+
+
+def test_delivery_settings_rejects_non_positive_retention_keep_last_n():
+    try:
+        DeliverySettings(retention_keep_last_n=0, retention_prefix="Daily Goose ")
+    except ValueError as err:
+        assert "retention_keep_last_n must be a positive integer" in str(err)
+    else:
+        assert False, "Expected ValueError"
+
+
+def test_delivery_settings_accepts_matching_retention_pair():
+    delivery = DeliverySettings(retention_keep_last_n=5, retention_prefix="Daily Goose ")
+    assert delivery.retention_keep_last_n == 5
+    assert delivery.retention_prefix == "Daily Goose "
+
+
+def test_resolve_delivery_settings_retention_cli_overrides_user_default():
+    delivery = resolve_delivery_settings(
+        user_defaults=DeliverySettings(
+            retention_keep_last_n=7, retention_prefix="Old Prefix "
+        ),
+        retention_keep_last_n_override=3,
+        retention_prefix_override="New Prefix ",
+    )
+    assert delivery.retention_keep_last_n == 3
+    assert delivery.retention_prefix == "New Prefix "
+
+
+def test_load_user_config_parses_retention_from_delivery_defaults():
+    with _TempWorkspace() as tmp_path:
+        os.environ["XDG_CONFIG_HOME"] = str(tmp_path)
+        _write_json(
+            tmp_path / "goosepaper" / "config.json",
+            {
+                "version": 2,
+                "delivery_defaults": {
+                    "retention_keep_last_n": 7,
+                    "retention_prefix": "Daily Goose ",
+                },
+            },
+        )
+
+        config = load_user_config()
+
+        assert config.delivery_defaults.retention_keep_last_n == 7
+        assert config.delivery_defaults.retention_prefix == "Daily Goose "
+
+
 def test_resolve_runtime_config_merges_user_defaults_and_cli():
     with _TempWorkspace() as tmp_path:
         os.environ["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
@@ -166,6 +231,52 @@ def test_resolve_runtime_config_merges_user_defaults_and_cli():
         assert config.delivery.replace_mode == "exact"
         assert config.delivery.cleanup is False
         assert config.deliver is True
+
+
+def test_resolve_runtime_config_accepts_retention_cli_flags():
+    with _TempWorkspace() as tmp_path:
+        os.environ["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
+        _write_json(
+            tmp_path / "goosepaper.json",
+            {
+                "version": 2,
+                "paper": {"style": "Academy"},
+                "sources": [{"type": "text", "headline": "hello"}],
+            },
+        )
+
+        config = resolve_runtime_config(
+            [
+                "--deliver",
+                "--retention-keep-last-n",
+                "7",
+                "--retention-prefix",
+                "Daily Goose ",
+            ]
+        )
+
+        assert config.delivery.retention_keep_last_n == 7
+        assert config.delivery.retention_prefix == "Daily Goose "
+
+
+def test_resolve_runtime_config_requires_deliver_for_retention_flags():
+    with _TempWorkspace() as tmp_path:
+        os.environ["XDG_CONFIG_HOME"] = str(tmp_path / "xdg")
+        _write_json(
+            tmp_path / "goosepaper.json",
+            {
+                "version": 2,
+                "paper": {"style": "Academy"},
+                "sources": [{"type": "text", "headline": "hello"}],
+            },
+        )
+
+        _assert_config_error(
+            lambda: resolve_runtime_config(
+                ["--retention-keep-last-n", "7", "--retention-prefix", "Daily Goose "]
+            ),
+            "Delivery override flags require '--deliver'",
+        )
 
 
 def test_load_paper_config_accepts_auto_layout_and_null_body_font():

--- a/goosepaper/test_upload.py
+++ b/goosepaper/test_upload.py
@@ -142,7 +142,7 @@ def test_upload_retention_deletes_older_editions_beyond_keep_last_n(monkeypatch,
         # retention, since its name doesn't start with the "Daily Goose " prefix.
         _IndexedItem("doc-other", "Weekly Roundup 2026-08-05", "folder-1", "DocumentType"),
     ]
-    monkeypatch.setattr("goosepaper.upload.auth_client", lambda: client)
+    monkeypatch.setattr("goosepaper.upload.auth_client", lambda **kwargs: client)
 
     filepath = tmp_path / "Daily Goose 2026-08-06.pdf"
     filepath.write_bytes(b"%PDF-test")
@@ -181,7 +181,7 @@ def test_upload_without_retention_keep_last_n_never_deletes(monkeypatch, tmp_pat
     client._items = [
         _IndexedItem("doc-old", "Daily Goose 2026-08-01", "", "DocumentType"),
     ]
-    monkeypatch.setattr("goosepaper.upload.auth_client", lambda: client)
+    monkeypatch.setattr("goosepaper.upload.auth_client", lambda **kwargs: client)
 
     filepath = tmp_path / "Daily Goose 2026-08-06.pdf"
     filepath.write_bytes(b"%PDF-test")

--- a/goosepaper/test_upload.py
+++ b/goosepaper/test_upload.py
@@ -15,8 +15,8 @@ class _Client:
         self.calls = []
         self._items = []
 
-    def list_items(self):
-        self.calls.append("list_items")
+    def list_items(self, refresh=False):
+        self.calls.append(("list_items", refresh))
         return self._items
 
     def upload_pdf(self, visible_name, payload):
@@ -63,7 +63,7 @@ def test_upload_root_pdf_uses_simple_upload_without_listing(monkeypatch, tmp_pat
 
     assert result is not False
     assert ("upload_pdf", "paper", b"%PDF-test") in client.calls
-    assert "list_items" not in client.calls
+    assert not any(call[0] == "list_items" for call in client.calls)
 
 
 def test_upload_defaults_to_interactive_auth(monkeypatch, tmp_path):
@@ -113,7 +113,7 @@ def test_upload_with_folder_scans_minimal_index(monkeypatch, tmp_path):
     result = upload(filepath, DeliverySettings(folder="News", replace_mode="never", cleanup=False))
 
     assert result is not False
-    assert "list_items" in client.calls
+    assert ("list_items", False) in client.calls
     assert ("put_pdf", "paper", b"%PDF-test", "folder-1", True) in client.calls
 
 
@@ -167,6 +167,13 @@ def test_upload_retention_deletes_older_editions_beyond_keep_last_n(monkeypatch,
     delete_calls = [call for call in client.calls if call[0] == "delete"]
     deleted_ids = {call[1] for call in delete_calls}
     assert deleted_ids == {"doc-2026-08-03"}
+
+    # The retention scan must force a fresh list_items() call (refresh=True) rather than trust
+    # whatever was already cached from the folder-resolution scan earlier in upload() - Client
+    # only refreshes that cache on put_pdf()/put_epub(), not on the plain upload_pdf()/
+    # upload_epub() root-level path, so an unqualified call here could read stale data depending
+    # on which path the upload actually took.
+    assert ("list_items", True) in client.calls
 
 
 def test_upload_without_retention_keep_last_n_never_deletes(monkeypatch, tmp_path):

--- a/goosepaper/test_upload.py
+++ b/goosepaper/test_upload.py
@@ -129,3 +129,57 @@ def test_upload_with_new_folder_uses_put_folder_and_nested_put_pdf(monkeypatch, 
     assert result is not False
     assert ("put_folder", "News", "", True) in client.calls
     assert ("put_pdf", "paper", b"%PDF-test", "folder-1", True) in client.calls
+
+
+def test_upload_retention_deletes_older_editions_beyond_keep_last_n(monkeypatch, tmp_path):
+    client = _Client()
+    client._items = [
+        _IndexedItem("folder-1", "News", "", "CollectionType"),
+        _IndexedItem("doc-2026-08-03", "Daily Goose 2026-08-03", "folder-1", "DocumentType"),
+        _IndexedItem("doc-2026-08-04", "Daily Goose 2026-08-04", "folder-1", "DocumentType"),
+        _IndexedItem("doc-2026-08-05", "Daily Goose 2026-08-05", "folder-1", "DocumentType"),
+        # A different paper sharing the same folder - must never be touched by this paper's
+        # retention, since its name doesn't start with the "Daily Goose " prefix.
+        _IndexedItem("doc-other", "Weekly Roundup 2026-08-05", "folder-1", "DocumentType"),
+    ]
+    monkeypatch.setattr("goosepaper.upload.auth_client", lambda: client)
+
+    filepath = tmp_path / "Daily Goose 2026-08-06.pdf"
+    filepath.write_bytes(b"%PDF-test")
+
+    result = upload(
+        filepath,
+        DeliverySettings(
+            folder="News",
+            replace_mode="never",
+            cleanup=False,
+            retention_keep_last_n=2,
+            retention_prefix="Daily Goose ",
+        ),
+    )
+
+    assert result is not False
+    # This fake client's list_items() doesn't grow from put_pdf/upload_pdf calls (unlike the real
+    # API), so the retention scan only ever sees the three pre-seeded "Daily Goose" editions
+    # (-05, -04, -03), not the one just uploaded - keep_last_n=2 keeps the newest two of those
+    # (-05, -04) and deletes -03. The unrelated "Weekly Roundup" document is never touched,
+    # confirming the prefix match is doing its job.
+    delete_calls = [call for call in client.calls if call[0] == "delete"]
+    deleted_ids = {call[1] for call in delete_calls}
+    assert deleted_ids == {"doc-2026-08-03"}
+
+
+def test_upload_without_retention_keep_last_n_never_deletes(monkeypatch, tmp_path):
+    client = _Client()
+    client._items = [
+        _IndexedItem("doc-old", "Daily Goose 2026-08-01", "", "DocumentType"),
+    ]
+    monkeypatch.setattr("goosepaper.upload.auth_client", lambda: client)
+
+    filepath = tmp_path / "Daily Goose 2026-08-06.pdf"
+    filepath.write_bytes(b"%PDF-test")
+
+    result = upload(filepath, DeliverySettings(replace_mode="never", cleanup=False))
+
+    assert result is not False
+    assert not any(call[0] == "delete" for call in client.calls)

--- a/goosepaper/upload.py
+++ b/goosepaper/upload.py
@@ -18,26 +18,29 @@ def _name_for_matching(value: str, nocase: bool) -> str:
     return value.lower() if nocase else value
 
 
-def _list_active_items(client):
-    return [item for item in client.list_items() if item.parent != "trash"]
+def _list_active_items(client, refresh: bool = False):
+    return [item for item in client.list_items(refresh=refresh) if item.parent != "trash"]
 
 
 def _apply_retention(client, parent_id: str, prefix: str, keep_last_n: int) -> None:
     """Deletes older documents in the same folder as the just-uploaded one, keeping only the
     `keep_last_n` most recent whose name starts with `prefix` - for a paper delivered on a
     schedule under a name like "Daily Goose 2026-08-05", `prefix` would be "Daily Goose " so this
-    matches every dated edition of that same paper (and nothing else sharing the folder) without
-    touching the one just uploaded, which is included in this same scan and is always the newest.
+    matches every dated edition of that same paper (and nothing else sharing the folder).
 
-    Runs as its own list_items() call after the upload completes, rather than reusing whatever
-    was already listed to resolve the folder/replace target above - simpler to reason about
-    correctly than adjusting for the just-uploaded document not yet existing in an earlier scan,
-    at the cost of one extra API round-trip.
+    Always passes refresh=True to list_items() here, deliberately not reusing whatever was
+    already listed to resolve the folder/replace target above: Client.list_items() caches the
+    root state and only re-fetches it when asked, and while put_pdf()/put_epub() (used whenever
+    a folder is involved, i.e. exactly when retention is usable at all) do refresh that cache via
+    their own refresh=True, upload_pdf()/upload_epub() (the plain root-level path) do not - so an
+    unqualified list_items() call here could silently read stale, pre-upload state depending on
+    which upload path just ran. Forcing refresh=True removes that as something to reason about,
+    at the cost of one guaranteed extra API round-trip.
     """
     editions = sorted(
         (
             item
-            for item in _list_active_items(client)
+            for item in _list_active_items(client, refresh=True)
             if item.type == "DocumentType"
             and item.parent == parent_id
             and item.visibleName.startswith(prefix)

--- a/goosepaper/upload.py
+++ b/goosepaper/upload.py
@@ -22,6 +22,33 @@ def _list_active_items(client):
     return [item for item in client.list_items() if item.parent != "trash"]
 
 
+def _apply_retention(client, parent_id: str, prefix: str, keep_last_n: int) -> None:
+    """Deletes older documents in the same folder as the just-uploaded one, keeping only the
+    `keep_last_n` most recent whose name starts with `prefix` - for a paper delivered on a
+    schedule under a name like "Daily Goose 2026-08-05", `prefix` would be "Daily Goose " so this
+    matches every dated edition of that same paper (and nothing else sharing the folder) without
+    touching the one just uploaded, which is included in this same scan and is always the newest.
+
+    Runs as its own list_items() call after the upload completes, rather than reusing whatever
+    was already listed to resolve the folder/replace target above - simpler to reason about
+    correctly than adjusting for the just-uploaded document not yet existing in an earlier scan,
+    at the cost of one extra API round-trip.
+    """
+    editions = sorted(
+        (
+            item
+            for item in _list_active_items(client)
+            if item.type == "DocumentType"
+            and item.parent == parent_id
+            and item.visibleName.startswith(prefix)
+        ),
+        key=lambda item: item.visibleName,
+        reverse=True,
+    )
+    for stale in editions[keep_last_n:]:
+        client.delete(stale.id, refresh=True)
+
+
 def upload(
     filepath,
     delivery_settings: Optional[DeliverySettings] = None,
@@ -118,6 +145,10 @@ def upload(
 
     if result is not None:
         print("Honk! Upload successful!")
+        if delivery.retention_keep_last_n is not None:
+            _apply_retention(
+                client, parent_id, delivery.retention_prefix, delivery.retention_keep_last_n
+            )
         if cleanup:
             try:
                 os.remove(fpr)
@@ -150,6 +181,19 @@ def main(args=None):
         default=None,
     )
     parser.add_argument(
+        "--retention-keep-last-n",
+        type=int,
+        required=False,
+        help='Keep only the last N delivered documents whose name starts with '
+        '"--retention-prefix", deleting older ones. Requires "--retention-prefix".',
+    )
+    parser.add_argument(
+        "--retention-prefix",
+        required=False,
+        help='The name prefix "--retention-keep-last-n" matches past editions against. '
+        'Requires "--retention-keep-last-n".',
+    )
+    parser.add_argument(
         "--showconfig",
         action="store_true",
         required=False,
@@ -171,6 +215,8 @@ def main(args=None):
             folder_override=parsed.folder,
             replace_mode_override=parsed.replace_mode,
             cleanup_override=parsed.cleanup,
+            retention_keep_last_n_override=parsed.retention_keep_last_n,
+            retention_prefix_override=parsed.retention_prefix,
         )
     except ConfigError as err:
         print(f"Honk! {err}")


### PR DESCRIPTION
## What

Two new `DeliverySettings` fields - `retention_keep_last_n` and `retention_prefix` - that prune older reMarkable documents after a successful delivery, keeping only the most recent N editions of a given paper.

## Why

Anyone running goosepaper on a schedule (a cron job invoking `--deliver` daily or weekly - the whole point of `--deliver`) accumulates one document per run in their reMarkable folder, forever. `replace_mode` already exists for collision handling, but it only ever matches an *exact* filename - it can't help once each run's output is named with a date (e.g. `"Daily Goose 2026-08-05"`), which is the normal way to avoid every run overwriting the last. There was no way to prune older editions without writing that logic yourself outside goosepaper against the remarkapy client directly.

## How it works

Both settings must be given together - `retention_keep_last_n` without a `retention_prefix` has nothing to match past editions against, and vice versa; `DeliverySettings.__post_init__` raises a `ConfigError`-wrapped `ValueError` if only one is set. Neither has a default, so retention is off unless explicitly opted into - no behavior change for existing callers.

Wired through the same three places `folder`/`replace_mode`/`cleanup` are already exposed:
- `delivery_defaults` in `~/.config/goosepaper/config.json`
- CLI flags: `--retention-keep-last-n` / `--retention-prefix`
- `upload()`'s own `DeliverySettings` parameter, for direct Python callers

Runs as `upload()`'s own final step, after a successful delivery: `list_items(refresh=True)`, filtered to `DocumentType` items in the same parent folder whose name starts with `retention_prefix`, sorted by name descending, deleting everything past `retention_keep_last_n`. A document in the same folder that doesn't match the prefix (a different paper sharing the folder) is never touched.

`refresh=True` is deliberate, not incidental: `Client.list_items()` caches the root state and only re-fetches on request. `put_pdf()`/`put_epub()` (used whenever a folder is involved, i.e. exactly when retention is usable at all) refresh that cache as part of the upload; `upload_pdf()`/`upload_epub()` (the plain root-level path) don't. Since the retention scan reuses the same client instance right after the upload call, an unqualified `list_items()` there could silently read stale, pre-upload state depending on which upload path had just run - forcing a real refresh removes that as something callers need to reason about, at the cost of one guaranteed extra round-trip.

## Testing

- `test_config.py`: `DeliverySettings` validation (both-or-neither, positive-int check), CLI parsing, `delivery_defaults` JSON parsing, full `resolve_runtime_config` end-to-end including the `--deliver`-required check.
- `test_upload.py`: actual deletion behavior against the existing fake remarkapy client fixture - keeps the newest N matching documents, deletes the rest, confirms a differently-prefixed document sharing the same folder is left alone, and asserts the retention scan specifically requests `refresh=True`.
- Full suite: 88 passed (78 previously + 10 new).

## Merge overlap note (real, not just mechanical)

Locally merging this branch together with **#137** (adds an `interactive=` kwarg to `auth_client()`/`upload()`) breaks 2 of this PR's own tests: `test_upload_retention_deletes_older_editions_beyond_keep_last_n` and `test_upload_without_retention_keep_last_n_never_deletes` mocked `auth_client` with a zero-arg `lambda: client`, copied from the master-baseline style at the time this PR was written. Once `upload()` starts calling `auth_client(interactive=interactive)` (from #137), that lambda raises `TypeError: unexpected keyword argument 'interactive'`. Neither PR is individually at fault - #137 already defensively updated every `auth_client` mock it saw when it was written, these two are just newer than that. Fixed here by matching the same `lambda **kwargs: client` pattern already used everywhere else in this file. Re-verified: merging both branches together now passes all tests on both sides.
