### PR TITLE
feat: add interactive parameter to auth_client()/upload()

### DIFF
--- a/goosepaper/auth.py
+++ b/goosepaper/auth.py
@@ -2,9 +2,17 @@ from remarkapy import Client, resolve_config_path
 from remarkapy.exceptions import RemarkableAPIError
 
 
-def auth_client():
+def auth_client(interactive: bool = True):
+    """`interactive` is forwarded to remarkapy's own `Client`, which defaults to `True` there
+    too - fine for a real terminal, where a missing device token falls into an `input()` pairing
+    wizard. In any unattended context (a cron job, a container with no stdin) that wizard's
+    `input()` call raises an uncaught `EOFError` instead of the clean, caught
+    `RemarkableAPIError` every other failure here already produces - pass `interactive=False` to
+    get that same clean handling (a caught `ConfigNotFoundError`, printed and returned as
+    `False`) instead of a crash.
+    """
     try:
-        client = Client(refresh_on_init=False)
+        client = Client(refresh_on_init=False, interactive=interactive)
         client.refresh_user_token()
         return client
     except RemarkableAPIError as err:

--- a/goosepaper/test_auth.py
+++ b/goosepaper/test_auth.py
@@ -1,0 +1,64 @@
+from remarkapy.exceptions import ConfigNotFoundError
+
+from . import auth
+
+
+class _FakeClient:
+    def __init__(self, refresh_on_init=False, interactive=True, has_token=True):
+        self.refresh_on_init = refresh_on_init
+        self.interactive = interactive
+        self.has_token = has_token
+
+    def refresh_user_token(self):
+        if not self.has_token and not self.interactive:
+            # Mirrors remarkapy's own Client.refresh_user_token(): with no device token and
+            # interactive pairing disabled, this is what actually gets raised - a clean,
+            # RemarkableAPIError-derived exception auth_client()'s except block already handles,
+            # rather than falling into an input()-based pairing wizard that would raise an
+            # uncaught EOFError in a context with no stdin (a cron job, a container).
+            raise ConfigNotFoundError(
+                "No device token is configured and interactive pairing is disabled."
+            )
+        return "token"
+
+
+def test_auth_client_defaults_to_interactive_for_backward_compatibility(monkeypatch):
+    seen = {}
+
+    def fake_client(**kwargs):
+        seen.update(kwargs)
+        return _FakeClient(**kwargs)
+
+    monkeypatch.setattr(auth, "Client", fake_client)
+
+    result = auth.auth_client()
+
+    assert seen["interactive"] is True
+    assert result is not False
+
+
+def test_auth_client_passes_interactive_false_through_to_client(monkeypatch):
+    seen = {}
+
+    def fake_client(**kwargs):
+        seen.update(kwargs)
+        return _FakeClient(**kwargs)
+
+    monkeypatch.setattr(auth, "Client", fake_client)
+
+    result = auth.auth_client(interactive=False)
+
+    assert seen["interactive"] is False
+    assert result is not False
+
+
+def test_auth_client_fails_cleanly_instead_of_crashing_when_noninteractive_and_unpaired(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        auth, "Client", lambda **kwargs: _FakeClient(has_token=False, **kwargs)
+    )
+
+    result = auth.auth_client(interactive=False)
+
+    assert result is False

--- a/goosepaper/test_upload.py
+++ b/goosepaper/test_upload.py
@@ -54,7 +54,7 @@ class _Client:
 
 def test_upload_root_pdf_uses_simple_upload_without_listing(monkeypatch, tmp_path):
     client = _Client()
-    monkeypatch.setattr("goosepaper.upload.auth_client", lambda: client)
+    monkeypatch.setattr("goosepaper.upload.auth_client", lambda **kwargs: client)
 
     filepath = tmp_path / "paper.pdf"
     filepath.write_bytes(b"%PDF-test")
@@ -66,10 +66,46 @@ def test_upload_root_pdf_uses_simple_upload_without_listing(monkeypatch, tmp_pat
     assert "list_items" not in client.calls
 
 
+def test_upload_defaults_to_interactive_auth(monkeypatch, tmp_path):
+    seen = {}
+    client = _Client()
+    monkeypatch.setattr(
+        "goosepaper.upload.auth_client",
+        lambda **kwargs: seen.update(kwargs) or client,
+    )
+
+    filepath = tmp_path / "paper.pdf"
+    filepath.write_bytes(b"%PDF-test")
+
+    upload(filepath, DeliverySettings(folder=None, replace_mode="never", cleanup=False))
+
+    assert seen["interactive"] is True
+
+
+def test_upload_passes_interactive_false_through_to_auth_client(monkeypatch, tmp_path):
+    seen = {}
+    client = _Client()
+    monkeypatch.setattr(
+        "goosepaper.upload.auth_client",
+        lambda **kwargs: seen.update(kwargs) or client,
+    )
+
+    filepath = tmp_path / "paper.pdf"
+    filepath.write_bytes(b"%PDF-test")
+
+    upload(
+        filepath,
+        DeliverySettings(folder=None, replace_mode="never", cleanup=False),
+        interactive=False,
+    )
+
+    assert seen["interactive"] is False
+
+
 def test_upload_with_folder_scans_minimal_index(monkeypatch, tmp_path):
     client = _Client()
     client._items = [_IndexedItem("folder-1", "News", "", "CollectionType")]
-    monkeypatch.setattr("goosepaper.upload.auth_client", lambda: client)
+    monkeypatch.setattr("goosepaper.upload.auth_client", lambda **kwargs: client)
 
     filepath = tmp_path / "paper.pdf"
     filepath.write_bytes(b"%PDF-test")
@@ -83,7 +119,7 @@ def test_upload_with_folder_scans_minimal_index(monkeypatch, tmp_path):
 
 def test_upload_with_new_folder_uses_put_folder_and_nested_put_pdf(monkeypatch, tmp_path):
     client = _Client()
-    monkeypatch.setattr("goosepaper.upload.auth_client", lambda: client)
+    monkeypatch.setattr("goosepaper.upload.auth_client", lambda **kwargs: client)
 
     filepath = tmp_path / "paper.pdf"
     filepath.write_bytes(b"%PDF-test")

--- a/goosepaper/upload.py
+++ b/goosepaper/upload.py
@@ -22,7 +22,12 @@ def _list_active_items(client):
     return [item for item in client.list_items() if item.parent != "trash"]
 
 
-def upload(filepath, delivery_settings: Optional[DeliverySettings] = None, showconfig=False):
+def upload(
+    filepath,
+    delivery_settings: Optional[DeliverySettings] = None,
+    showconfig=False,
+    interactive: bool = True,
+):
     filepath = Path(filepath)
     delivery = _coerce_delivery_settings(delivery_settings)
 
@@ -34,7 +39,7 @@ def upload(filepath, delivery_settings: Optional[DeliverySettings] = None, showc
     if showconfig:
         print(json.dumps(delivery.to_dict(), indent=2))
 
-    client = auth_client()
+    client = auth_client(interactive=interactive)
 
     if not client:
         print("Honk Honk! Couldn't auth! Is your remarkapy config set up (~/.rmapi)?")
@@ -150,6 +155,14 @@ def main(args=None):
         required=False,
         help="Print the resolved delivery settings before uploading.",
     )
+    parser.add_argument(
+        "--no-interactive",
+        dest="interactive",
+        action="store_false",
+        default=True,
+        help="Fail with a clean error instead of prompting for reMarkable pairing if no device "
+        "token is configured. For unattended use (cron, CI) where there's no terminal to prompt.",
+    )
     parsed = parser.parse_args(args)
 
     try:
@@ -167,6 +180,7 @@ def main(args=None):
         parsed.filepath,
         delivery_settings=delivery,
         showconfig=parsed.showconfig,
+        interactive=parsed.interactive,
     )
     return 0 if result else 1
 


### PR DESCRIPTION
## What

Adds `interactive: bool = True` to `auth_client()` and `upload()`, threaded through to a new `--no-interactive` flag on the standalone `upload_to_remarkable` CLI.

## Why

`auth_client()` builds its `Client` with remarkapy's own `interactive=True` default. That's the right default on a real terminal - a missing device token falls into an `input()`-based pairing wizard. But in any unattended context (a cron job invoking `--deliver` on a schedule, a container with no stdin - realistically the only way `--deliver` gets used repeatedly) that wizard's `input()` call raises an **uncaught `EOFError`** instead of the clean, caught `RemarkableAPIError` every other `auth_client()` failure already produces and handles gracefully.

Verified directly against remarkapy (no mocks), with an isolated empty config file and stdin closed:

```
=== interactive=True (previous only option), no token, no stdin ===

=== REMARKABLE CLOUD ===
Visit https://my.remarkable.com/pair/app and enter the displayed code.
Verification code: confirmed: uncaught EOFError - EOF when reading a line

=== interactive=False (this PR), no token ===
clean RemarkableAPIError caught: ConfigNotFoundError No device token is configured and interactive pairing is disabled.
```

## How

- `interactive: bool = True` on `auth_client()`, forwarded to `Client(refresh_on_init=False, interactive=interactive)`. Default unchanged, so existing interactive callers see no behavior change.
- `interactive: bool = True` on `upload()`, forwarded to its own `auth_client(interactive=interactive)` call - lets a caller doing scheduled/unattended delivery opt into clean failure instead of a crash, without needing to reimplement or monkeypatch `auth_client()` themselves.
- `--no-interactive` on the standalone `upload_to_remarkable` CLI, for unattended use (cron, CI) where there's no terminal to prompt.

## Testing

- `test_auth.py` (new): parameter threading (`interactive=True`/`False` both reach the constructed `Client`), and the clean-failure path (a no-token, non-interactive `Client` produces a caught `RemarkableAPIError`, returned as `False`, not an uncaught exception).
- `test_upload.py`: `upload()`'s own default and override, confirming it reaches `auth_client()` correctly.
- Full suite: 83 passed (78 previously + 5 new).

## Merge overlap note (real, not just mechanical)

Locally merging this branch together with **#136** (adds retention pruning to `upload()`) broke 2 of #136's own tests: two of its `auth_client` mocks were still zero-arg `lambda: client`, which this PR's new `auth_client(interactive=interactive)` call breaks with a `TypeError`. Not a flaw in this PR - it already defensively updated every pre-existing `auth_client` mock it saw at the time it was written (see the diff in `test_upload.py` above) - #136 just added two more after that. Fixed on #136's side; re-verified both branches merged together now pass all tests.

