### PR TITLE
Add register_story_provider for external story providers

### DIFF
--- a/goosepaper/__init__.py
+++ b/goosepaper/__init__.py
@@ -1,2 +1,3 @@
 from .goosepaper import Goosepaper  # noqa
+from .util import register_story_provider  # noqa
 from .version import __version__  # noqa

--- a/goosepaper/config.py
+++ b/goosepaper/config.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 from goosepaper.layout import LAYOUT_CHOICES
 from goosepaper.styles import PAGE_PROFILE_CHOICES
-from goosepaper.util import load_config_file
+from goosepaper.util import load_config_file, registered_story_providers
 
 
 CONFIG_VERSION = 2
@@ -624,13 +624,19 @@ def _source_schema(source_type: str) -> Dict[str, Any]:
             "optional": set(),
         },
     }
-    if source_type not in schemas:
-        raise ConfigError(
-            f'Unknown source type "{source_type}". Supported source types are: '
-            + ", ".join(sorted(schemas))
-            + "."
-        )
-    return schemas[source_type]
+    if source_type in schemas:
+        return schemas[source_type]
+    registered = registered_story_providers()
+    if source_type in registered:
+        return {
+            "required": registered[source_type]["required"],
+            "optional": registered[source_type]["optional"],
+        }
+    raise ConfigError(
+        f'Unknown source type "{source_type}". Supported source types are: '
+        + ", ".join(sorted({*schemas, *registered}))
+        + "."
+    )
 
 
 def _validate_source_options(source_type: str, options: Dict[str, Any], index: int):
@@ -676,7 +682,9 @@ def _validate_source_options(source_type: str, options: Dict[str, Any], index: i
     }
 
     for key, value in options.items():
-        validators[key](value)
+        # Registered (external) providers may declare fields the built-ins don't
+        # know how to validate; those are the provider's own concern.
+        validators.get(key, lambda value: None)(value)
 
     if source_type == "wikipedia" and options:
         raise ConfigError("Wikipedia sources do not accept any additional fields.")

--- a/goosepaper/test_config.py
+++ b/goosepaper/test_config.py
@@ -286,6 +286,31 @@ def test_load_paper_config_rejects_invalid_rss_body_source():
         )
 
 
+def test_load_paper_config_accepts_registered_source():
+    from .util import register_story_provider
+
+    register_story_provider(
+        "dummy_cfg_provider", object, required={"handle"}, optional={"limit"}
+    )
+    with _TempWorkspace() as tmp_path:
+        config_path = tmp_path / "paper.json"
+        _write_json(
+            config_path,
+            {
+                "version": 2,
+                "paper": {"style": "FifthAvenue"},
+                "sources": [
+                    {"type": "dummy_cfg_provider", "handle": "goose", "limit": 2}
+                ],
+            },
+        )
+
+        config = load_paper_config(config_path)
+
+        assert config.sources[0].type == "dummy_cfg_provider"
+        assert config.sources[0].options == {"handle": "goose", "limit": 2}
+
+
 def test_load_paper_config_accepts_bluesky_source():
     with _TempWorkspace() as tmp_path:
         config_path = tmp_path / "paper.json"

--- a/goosepaper/test_utils.py
+++ b/goosepaper/test_utils.py
@@ -4,6 +4,7 @@ from .util import (
     construct_story_providers_from_source_configs,
     construct_story_providers_from_config_dict,
     htmlize,
+    register_story_provider,
 )
 
 
@@ -48,6 +49,25 @@ def test_construct_story_providers_from_config_dict():
         ]
     )
     assert len(stories) == 2
+
+
+def test_register_story_provider_makes_a_custom_type_constructable():
+    class _DummyProvider:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def get_stories(self, limit: int = 1):
+            return []
+
+    register_story_provider(
+        "dummy_test_provider", _DummyProvider, required={"handle"}, optional={"limit"}
+    )
+    stories = construct_story_providers_from_source_configs(
+        [{"type": "dummy_test_provider", "handle": "goose", "limit": 3}]
+    )
+    assert len(stories) == 1
+    assert isinstance(stories[0], _DummyProvider)
+    assert stories[0].kwargs == {"handle": "goose", "limit": 3}
 
 
 def test_construct_story_providers_passes_rss_byline_option():

--- a/goosepaper/util.py
+++ b/goosepaper/util.py
@@ -65,6 +65,44 @@ def construct_story_providers_from_config_dict(config: dict):
     return construct_story_providers_from_source_configs(config["sources"])
 
 
+_REGISTERED_STORY_PROVIDERS = {}
+
+
+def register_story_provider(
+    source_type, provider, *, required=None, optional=None, normalize=None
+):
+    """Register a StoryProvider so it can be used from a config file (and the CLI)
+    via ``{"type": source_type, ...}``, the same way the built-in providers are.
+
+    Args:
+        source_type: the string used as a source ``"type"`` in a config.
+        provider: the StoryProvider class, or a ``"module.path:ClassName"`` string
+            that is imported lazily the first time the type is used.
+        required: config field names that must be present for this source.
+        optional: config field names that may be present.
+        normalize: maps the source's config options to the provider's constructor
+            kwargs; defaults to passing the options through unchanged.
+    """
+    _REGISTERED_STORY_PROVIDERS[source_type] = {
+        "provider": provider,
+        "required": set(required or ()),
+        "optional": set(optional or ()),
+        "normalize": normalize or (lambda options: dict(options)),
+    }
+
+
+def registered_story_providers():
+    """The registry of externally-registered providers (see register_story_provider)."""
+    return _REGISTERED_STORY_PROVIDERS
+
+
+def _resolve_provider(provider):
+    if isinstance(provider, str):
+        module_name, _, class_name = provider.replace(":", ".").rpartition(".")
+        return getattr(importlib.import_module(module_name), class_name)
+    return provider
+
+
 def construct_story_providers_from_source_configs(source_configs):
     provider_specs = {
         "text": (
@@ -147,12 +185,17 @@ def construct_story_providers_from_source_configs(source_configs):
 
     for source_config in source_configs:
         source_type, options = _source_config_parts(source_config)
-        if source_type not in provider_specs:
+        if source_type in provider_specs:
+            module_name, class_name, normalize = provider_specs[source_type]
+            module = importlib.import_module(module_name)
+            provider_class = getattr(module, class_name)
+            stories.append(provider_class(**normalize(options)))
+        elif source_type in _REGISTERED_STORY_PROVIDERS:
+            spec = _REGISTERED_STORY_PROVIDERS[source_type]
+            provider_class = _resolve_provider(spec["provider"])
+            stories.append(provider_class(**spec["normalize"](options)))
+        else:
             raise ValueError(f"Source type {source_type} does not exist.")
-        module_name, class_name, normalize = provider_specs[source_type]
-        module = importlib.import_module(module_name)
-        provider_class = getattr(module, class_name)
-        stories.append(provider_class(**normalize(options)))
     return stories
 
 


### PR DESCRIPTION
Adds a register_story_provider() so external packages can plug in their own source types and use them straight from a config file, the same way the built-in providers do.