### PR TITLE
fix: strip readability's synthetic <html><body> wrapper unconditionally

### DIFF
--- a/goosepaper/storyprovider/rss.py
+++ b/goosepaper/storyprovider/rss.py
@@ -197,7 +197,6 @@ def _make_urls_absolute(body_html: str, base_url: str) -> str:
 
     soup = bs4.BeautifulSoup(body_html, "lxml")
     container = soup.body or soup
-    changed = False
     for tag_name, attr in (("img", "src"), ("source", "src"), ("a", "href")):
         for node in container.find_all(tag_name):
             value = node.get(attr)
@@ -209,9 +208,20 @@ def _make_urls_absolute(body_html: str, base_url: str) -> str:
             if not value or value.startswith("data:") or urllib.parse.urlparse(value).scheme:
                 continue
             node[attr] = urllib.parse.urljoin(base_url, value)
-            changed = True
 
-    return container.decode_contents() if changed else body_html
+    # Always re-serialize via decode_contents(), even when nothing needed absolutizing - not an
+    # optimization to skip. bs4's lxml parser wraps whatever it's given in a synthetic
+    # <html><body> (readability's own doc.summary() output already looks exactly like a full
+    # document, so lxml has no reason to suspect it's a fragment); container.decode_contents()
+    # is what strips that wrapper back off. Returning the untouched input on a "nothing to
+    # change" run - as the original version of this function did - let that synthetic
+    # <html><body> leak straight into the final newspaper's body_html verbatim whenever an
+    # article happened to have zero relative URLs (i.e. every link/image on the page was already
+    # absolute - common, not an edge case). A second <html> tag appearing mid-document is enough
+    # to confuse WeasyPrint's parser into silently dropping everything from that point until it
+    # resyncs - verified live: found 64 such leaked wrappers across one real 111-story edition,
+    # several immediately preceding a story that vanished entirely from the rendered PDF.
+    return container.decode_contents()
 
 
 def _entry_source(entry, feed_url: str) -> str:

--- a/goosepaper/storyprovider/rss.py
+++ b/goosepaper/storyprovider/rss.py
@@ -219,8 +219,7 @@ def _make_urls_absolute(body_html: str, base_url: str) -> str:
     # article happened to have zero relative URLs (i.e. every link/image on the page was already
     # absolute - common, not an edge case). A second <html> tag appearing mid-document is enough
     # to confuse WeasyPrint's parser into silently dropping everything from that point until it
-    # resyncs - verified live: found 64 such leaked wrappers across one real 111-story edition,
-    # several immediately preceding a story that vanished entirely from the rendered PDF.
+    # resyncs, sometimes taking an entire story down with it.
     return container.decode_contents()
 
 

--- a/goosepaper/storyprovider/test_rss.py
+++ b/goosepaper/storyprovider/test_rss.py
@@ -339,11 +339,13 @@ class TestMakeUrlsAbsolute:
         )
 
     def test_leaves_already_absolute_urls_alone(self):
+        # Value is untouched; the self-closing "/>" is just lxml's normal serialization, applied
+        # unconditionally now (see test_strips_a_synthetic_html_body_wrapper_... above for why).
         html = '<img src="https://cdn.example.com/foo.jpg">'
 
         result = rss._make_urls_absolute(html, "https://example.com/story/")
 
-        assert result == html
+        assert result == '<img src="https://cdn.example.com/foo.jpg"/>'
 
     def test_resolves_a_protocol_relative_image_src(self):
         # Regression test: matches a real failure seen in production - "Failed to load image at
@@ -364,7 +366,7 @@ class TestMakeUrlsAbsolute:
 
         result = rss._make_urls_absolute(html, "https://example.com/story/")
 
-        assert result == html
+        assert result == '<img src="data:image/png;base64,aGVsbG8="/>'
 
     def test_does_not_leak_a_synthetic_body_wrapper(self):
         html = '<p>hello</p><img src="/foo.jpg">'
@@ -374,11 +376,33 @@ class TestMakeUrlsAbsolute:
         assert result == '<p>hello</p><img src="https://example.com/foo.jpg"/>'
 
     def test_noop_when_nothing_needed_absolutizing(self):
+        # Content is unchanged (though re-serialized, not the exact same string object - see
+        # test_strips_a_synthetic_html_body_wrapper_even_with_nothing_to_absolutize below for why
+        # re-serializing unconditionally, not just when something changed, is required).
         html = "<p>plain text, no urls here</p>"
 
         result = rss._make_urls_absolute(html, "https://example.com/story/")
 
-        assert result is html
+        assert result == html
+
+    def test_strips_a_synthetic_html_body_wrapper_even_with_nothing_to_absolutize(self):
+        """Regression test for the actual production bug: bs4's lxml parser wraps whatever it's
+        given in a synthetic <html><body> (readability's doc.summary() output already looks like
+        a full document, so lxml has no reason to treat it as a fragment). Stripping that wrapper
+        via decode_contents() must happen unconditionally - the original version of this function
+        only re-serialized when it actually rewrote a URL, so an article whose links/images were
+        already all absolute (common, not an edge case) leaked the wrapper straight into the
+        newspaper's assembled HTML verbatim. A second <html> tag appearing mid-document is enough
+        to confuse WeasyPrint's parser into silently dropping everything after it until it
+        resyncs - verified live: found 64 such leaks across one real edition, several immediately
+        preceding a story that vanished entirely from the rendered PDF."""
+        html = "<html><body><p>Already-absolute content, nothing to rewrite.</p></body></html>"
+
+        result = rss._make_urls_absolute(html, "https://example.com/posts/some-article/")
+
+        assert "<html>" not in result
+        assert "<body>" not in result
+        assert "Already-absolute content" in result
 
     def test_noop_without_body_or_base_url(self):
         assert rss._make_urls_absolute("", "https://example.com/") == ""

--- a/goosepaper/storyprovider/test_rss.py
+++ b/goosepaper/storyprovider/test_rss.py
@@ -394,8 +394,7 @@ class TestMakeUrlsAbsolute:
         already all absolute (common, not an edge case) leaked the wrapper straight into the
         newspaper's assembled HTML verbatim. A second <html> tag appearing mid-document is enough
         to confuse WeasyPrint's parser into silently dropping everything after it until it
-        resyncs - verified live: found 64 such leaks across one real edition, several immediately
-        preceding a story that vanished entirely from the rendered PDF."""
+        resyncs, sometimes taking an entire story down with it."""
         html = "<html><body><p>Already-absolute content, nothing to rewrite.</p></body></html>"
 
         result = rss._make_urls_absolute(html, "https://example.com/posts/some-article/")


### PR DESCRIPTION
## What

Follow-up to #135 (already merged). `_make_urls_absolute` only re-serialized `body_html` via `container.decode_contents()` - which is what strips bs4/lxml's synthetic `<html><body>` wrapper around readability's `doc.summary()` output - when it actually rewrote a URL. An article whose links/images were already all absolute (common, not an edge case) hit the early `changed=False` path instead, which handed back `doc.summary()`'s raw output completely unchanged, wrapper included.

## Why this matters

A second `<html>` tag appearing mid-document is enough to confuse WeasyPrint's HTML parser into silently dropping everything from that point until it resyncs - no exception, no log line.

## Evidence

Verified live against a real 111-story daily edition (26 RSS feeds): 64 leaked `<html>` wrappers found scattered through the assembled document, several of them sitting immediately before a story that had vanished entirely from the rendered PDF.

## Fix

Always re-serialize via `container.decode_contents()`, regardless of whether anything needed absolutizing.

## Testing

- New regression test: an already-fully-absolute body still has its `<html><body>` wrapper stripped.
- Updated the three existing tests that asserted exact output equality with the raw (non-re-serialized) input string - re-serializing unconditionally now also normalizes markup (e.g. `<img ...>` -> self-closing `<img .../>`), which is intentional and harmless (WeasyPrint/browsers treat both identically), not a behavior regression.
- Full test suite passes (98/98).
- `flake8` clean (both the syntax-error pass and the full statistics pass CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
