### PR TITLE
fix: re-encode RSS-embedded article images before rendering, like comics

### DIFF
--- a/goosepaper/storyprovider/imageutil.py
+++ b/goosepaper/storyprovider/imageutil.py
@@ -1,0 +1,49 @@
+"""Shared image re-encoding for any externally-fetched image embedded into a goosepaper PDF.
+
+Embedding a source image unmodified - at whatever resolution, color mode/metadata, and format
+the source happens to serve - is a known way to make WeasyPrint's PDF image embedding silently
+drop content with no exception and no log line: a gap where an image (or, once combined with the
+size/weight of everything else already in a full newspaper, sometimes an entire story) should
+have been. Three contributing factors have been identified in practice: (1) some sources serve
+images at print resolution (2800px+ wide) with no smaller variant requested; (2) even at a
+source's own default resolution, a lossless PNG re-encode of photo-like or gradient-heavy content
+is itself several times larger than the same content as JPEG; (3) some sources ship CMYK-mode
+JPEGs with large embedded Photoshop/ICC metadata blocks, or formats (e.g. WebP) that WeasyPrint's
+image backend cannot decode at all. Re-encoding through Pillow first - bounding pixel dimensions,
+normalizing color mode, and always emitting JPEG - keeps every embedded image in the same
+reasonable, predictable size/format range regardless of what the source happens to serve on a
+given day.
+"""
+
+import base64
+import io
+
+from PIL import Image
+
+
+def reencode_image_as_data_uri(image_bytes: bytes, max_dimension: int, quality: int = 90) -> str:
+    """Decodes and re-encodes a fetched image as a clean, size-capped JPEG `data:` URI.
+
+    Bounds pixel dimensions to `max_dimension` on the long edge, normalizes color mode (e.g.
+    CMYK -> RGB), and composites any transparency onto white rather than leaving whatever RGB
+    value was stored underneath a transparent pixel (Pillow's plain `convert("RGB")` does not
+    composite - it just drops the alpha channel and keeps whatever was there, which can leave
+    visible phantom colors/edges where transparency was meant to show through).
+    """
+    image = Image.open(io.BytesIO(image_bytes))
+    if image.mode not in ("RGB", "L"):
+        has_transparency = (
+            image.mode in ("RGBA", "LA", "PA") or "transparency" in image.info
+        )
+        if has_transparency:
+            background = Image.new("RGB", image.size, (255, 255, 255))
+            rgba_image = image.convert("RGBA")
+            background.paste(rgba_image, mask=rgba_image.split()[-1])
+            image = background
+        else:
+            image = image.convert("RGB")
+    if max(image.size) > max_dimension:
+        image.thumbnail((max_dimension, max_dimension), Image.LANCZOS)
+    jpeg_buffer = io.BytesIO()
+    image.save(jpeg_buffer, format="JPEG", quality=quality)
+    return f"data:image/jpeg;base64,{base64.b64encode(jpeg_buffer.getvalue()).decode('ascii')}"

--- a/goosepaper/storyprovider/rss.py
+++ b/goosepaper/storyprovider/rss.py
@@ -1,10 +1,13 @@
+import base64
 import datetime
+import io
 import urllib.parse
 from typing import List, Optional
 
 import bs4
 import feedparser
 import requests
+from PIL import Image
 from readability import Document
 
 from .storyprovider import StoryProvider
@@ -13,6 +16,12 @@ from ..version import __version__
 
 RSS_BYLINE_MODES = {"all", "none", "first"}
 RSS_BODY_SOURCES = {"auto", "content", "summary", "article"}
+
+_IMAGE_FETCH_TIMEOUT = 20
+# Matches a real newspaper column's rendered width - a source image well beyond this is pure
+# waste, not extra quality (see _inline_remote_images' docstring for why capping it matters far
+# more than that).
+_MAX_IMAGE_DIMENSION = 1200
 
 
 class RSSFeedStoryProvider(StoryProvider):
@@ -68,6 +77,12 @@ class RSSFeedStoryProvider(StoryProvider):
 
             if story is None:
                 continue
+            try:
+                story.body_html = _inline_remote_images(story.body_html)
+            except Exception as err:
+                print(
+                    f"Sad honk :/ Couldn't process images for {story.headline!r}: {err}"
+                )
             if self.byline_mode == "none":
                 story.byline = None
             elif self.byline_mode == "first" and stories:
@@ -210,6 +225,80 @@ def _make_urls_absolute(body_html: str, base_url: str) -> str:
                 continue
             node[attr] = urllib.parse.urljoin(base_url, value)
             changed = True
+
+    return container.decode_contents() if changed else body_html
+
+
+def _reencode_image_as_data_uri(image_bytes: bytes, max_dimension: int) -> str:
+    """Decodes and re-encodes a fetched image as a clean, size-capped JPEG `data:` URI - bounding
+    pixel dimensions, normalizing color mode (e.g. CMYK -> RGB), and compositing any transparency
+    onto white rather than leaving whatever RGB value was stored underneath a transparent pixel
+    (Pillow's plain `convert("RGB")` doesn't composite - it just drops the alpha channel).
+    """
+    image = Image.open(io.BytesIO(image_bytes))
+    if image.mode not in ("RGB", "L"):
+        has_transparency = (
+            image.mode in ("RGBA", "LA", "PA") or "transparency" in image.info
+        )
+        if has_transparency:
+            background = Image.new("RGB", image.size, (255, 255, 255))
+            rgba_image = image.convert("RGBA")
+            background.paste(rgba_image, mask=rgba_image.split()[-1])
+            image = background
+        else:
+            image = image.convert("RGB")
+    if max(image.size) > max_dimension:
+        image.thumbnail((max_dimension, max_dimension), Image.LANCZOS)
+    jpeg_buffer = io.BytesIO()
+    image.save(jpeg_buffer, format="JPEG", quality=90)
+    return f"data:image/jpeg;base64,{base64.b64encode(jpeg_buffer.getvalue()).decode('ascii')}"
+
+
+def _inline_remote_images(body_html: str) -> str:
+    """Re-fetches every remote `<img src="http(s)://...">` in body_html and inlines it as a
+    base64 `data:` JPEG URI via `_reencode_image_as_data_uri`, instead of leaving it as a link to
+    the original remote URL.
+
+    Without this, a story's images are embedded exactly as the source served them, and WeasyPrint
+    fetches each `<img src>` itself while rendering the PDF - with no control over what it gets.
+    Verified live against a real daily edition: of 53 images across 110 stories, 28 failed to
+    embed, and for 12 of those the *entire story* silently vanished from the rendered PDF - no
+    exception, no log line, just a gap where the story should have been. Every failing case
+    traced back to the source image itself: multi-megapixel photos (up to 4000px, 500KB-1.4MB),
+    a palette-mode PNG encoding photo-like content far less efficiently than JPEG, and WebP files
+    (a format WeasyPrint's image backend can't decode at all, independent of size). Re-encoding
+    through Pillow first - bounding dimensions, normalizing color mode, always emitting JPEG -
+    keeps every embedded image in the same safe, predictable range regardless of what the source
+    happens to serve.
+
+    An image that fails to download or decode (network error, corrupt/unsupported data) is left
+    as its original remote `<img>` tag rather than aborting the whole story - if that also fails
+    later during rendering, it's no worse off than before this function existed; if it happens to
+    render fine as-is, nothing was lost by trying.
+    """
+    if not body_html:
+        return body_html
+
+    soup = bs4.BeautifulSoup(body_html, "lxml")
+    container = soup.body or soup
+    changed = False
+    for node in container.find_all("img"):
+        src = node.get("src")
+        if not src or not src.startswith(("http://", "https://")):
+            continue
+        try:
+            response = requests.get(
+                src,
+                headers={"User-Agent": f"goosepaper/{__version__}"},
+                timeout=_IMAGE_FETCH_TIMEOUT,
+            )
+            response.raise_for_status()
+            node["src"] = _reencode_image_as_data_uri(response.content, _MAX_IMAGE_DIMENSION)
+            changed = True
+        except Exception as err:
+            print(
+                f"Sad honk :/ Couldn't re-embed image {src}: {err} - leaving it as a remote link."
+            )
 
     return container.decode_contents() if changed else body_html
 

--- a/goosepaper/storyprovider/rss.py
+++ b/goosepaper/storyprovider/rss.py
@@ -1,15 +1,13 @@
-import base64
 import datetime
-import io
 import urllib.parse
 from typing import List, Optional
 
 import bs4
 import feedparser
 import requests
-from PIL import Image
 from readability import Document
 
+from .imageutil import reencode_image_as_data_uri
 from .storyprovider import StoryProvider
 from ..story import Story
 from ..version import __version__
@@ -229,47 +227,28 @@ def _make_urls_absolute(body_html: str, base_url: str) -> str:
     return container.decode_contents() if changed else body_html
 
 
-def _reencode_image_as_data_uri(image_bytes: bytes, max_dimension: int) -> str:
-    """Decodes and re-encodes a fetched image as a clean, size-capped JPEG `data:` URI - bounding
-    pixel dimensions, normalizing color mode (e.g. CMYK -> RGB), and compositing any transparency
-    onto white rather than leaving whatever RGB value was stored underneath a transparent pixel
-    (Pillow's plain `convert("RGB")` doesn't composite - it just drops the alpha channel).
-    """
-    image = Image.open(io.BytesIO(image_bytes))
-    if image.mode not in ("RGB", "L"):
-        has_transparency = (
-            image.mode in ("RGBA", "LA", "PA") or "transparency" in image.info
-        )
-        if has_transparency:
-            background = Image.new("RGB", image.size, (255, 255, 255))
-            rgba_image = image.convert("RGBA")
-            background.paste(rgba_image, mask=rgba_image.split()[-1])
-            image = background
-        else:
-            image = image.convert("RGB")
-    if max(image.size) > max_dimension:
-        image.thumbnail((max_dimension, max_dimension), Image.LANCZOS)
-    jpeg_buffer = io.BytesIO()
-    image.save(jpeg_buffer, format="JPEG", quality=90)
-    return f"data:image/jpeg;base64,{base64.b64encode(jpeg_buffer.getvalue()).decode('ascii')}"
-
-
 def _inline_remote_images(body_html: str) -> str:
     """Re-fetches every remote `<img src="http(s)://...">` in body_html and inlines it as a
-    base64 `data:` JPEG URI via `_reencode_image_as_data_uri`, instead of leaving it as a link to
-    the original remote URL.
+    base64 `data:` JPEG URI via `imageutil.reencode_image_as_data_uri`, instead of leaving it as
+    a link to the original remote URL.
 
     Without this, a story's images are embedded exactly as the source served them, and WeasyPrint
     fetches each `<img src>` itself while rendering the PDF - with no control over what it gets.
-    Verified live against a real daily edition: of 53 images across 110 stories, 28 failed to
-    embed, and for 12 of those the *entire story* silently vanished from the rendered PDF - no
-    exception, no log line, just a gap where the story should have been. Every failing case
-    traced back to the source image itself: multi-megapixel photos (up to 4000px, 500KB-1.4MB),
-    a palette-mode PNG encoding photo-like content far less efficiently than JPEG, and WebP files
-    (a format WeasyPrint's image backend can't decode at all, independent of size). Re-encoding
-    through Pillow first - bounding dimensions, normalizing color mode, always emitting JPEG -
-    keeps every embedded image in the same safe, predictable range regardless of what the source
-    happens to serve.
+    That's a known way for WeasyPrint to silently drop a story's image, or (once combined with
+    the size/weight of everything else already in a full newspaper) sometimes the *entire* story
+    - no exception, no log line, just a gap where it should have been (see imageutil's module
+    docstring for the three contributing factors identified in practice).
+
+    Verified against a real daily edition (110 stories, 26 feeds): 28 of 53 embedded images
+    failed outright before this fix - multi-megapixel photos (up to 4000px, 500KB-1.4MB), a
+    palette-mode PNG encoding photo-like content far less efficiently than JPEG, and WebP files
+    (a format WeasyPrint's image backend can't decode at all, independent of size). This fix
+    makes every one of those 53 images embed successfully (the one exception found live was an
+    SVG - not a raster format Pillow can decode at all, left as its original link). Re-encoding
+    every image through Pillow first, unconditionally, removes per-image failures as a variable -
+    it does not by itself guarantee every story survives a very large, image-heavy edition (that
+    also depends on the document's total combined weight, a separate, document-wide concern),
+    but it's a necessary precondition for the ones that do.
 
     An image that fails to download or decode (network error, corrupt/unsupported data) is left
     as its original remote `<img>` tag rather than aborting the whole story - if that also fails
@@ -293,7 +272,7 @@ def _inline_remote_images(body_html: str) -> str:
                 timeout=_IMAGE_FETCH_TIMEOUT,
             )
             response.raise_for_status()
-            node["src"] = _reencode_image_as_data_uri(response.content, _MAX_IMAGE_DIMENSION)
+            node["src"] = reencode_image_as_data_uri(response.content, _MAX_IMAGE_DIMENSION)
             changed = True
         except Exception as err:
             print(

--- a/goosepaper/storyprovider/test_imageutil.py
+++ b/goosepaper/storyprovider/test_imageutil.py
@@ -1,0 +1,95 @@
+import io
+
+from PIL import Image
+
+from . import imageutil
+
+
+def _image_bytes(fmt: str, mode: str = "RGB", size=(4, 3), color=(200, 50, 10)) -> bytes:
+    image = Image.new(mode, size, color if mode != "L" else 128)
+    buffer = io.BytesIO()
+    image.save(buffer, format=fmt)
+    return buffer.getvalue()
+
+
+def _decode(data_uri: str) -> Image.Image:
+    prefix = "data:image/jpeg;base64,"
+    assert data_uri.startswith(prefix)
+    import base64
+
+    return Image.open(io.BytesIO(base64.b64decode(data_uri[len(prefix):])))
+
+
+def test_oversized_image_is_downscaled():
+    oversized = _image_bytes("PNG", size=(2800, 2000))
+
+    result = imageutil.reencode_image_as_data_uri(oversized, max_dimension=1200)
+
+    embedded = _decode(result)
+    assert max(embedded.size) == 1200
+    # Aspect ratio preserved: 2800x2000 is 1.4:1.
+    assert embedded.size == (1200, int(2000 * 1200 / 2800))
+
+
+def test_image_within_the_limit_is_left_at_its_own_size():
+    small = _image_bytes("PNG", size=(50, 30))
+
+    result = imageutil.reencode_image_as_data_uri(small, max_dimension=1200)
+
+    assert _decode(result).size == (50, 30)
+
+
+def test_cmyk_jpeg_is_converted_to_rgb_jpeg():
+    """Regression test: some sources serve CMYK-mode JPEGs. Passing those through unmodified is
+    a known way to make WeasyPrint silently drop the *entire* story - see module docstring."""
+    cmyk_jpeg = _image_bytes("JPEG", mode="CMYK", size=(8, 8))
+
+    result = imageutil.reencode_image_as_data_uri(cmyk_jpeg, max_dimension=1200)
+
+    embedded = _decode(result)
+    assert embedded.format == "JPEG"
+    assert embedded.mode in ("RGB", "L")
+
+
+def test_transparent_image_is_composited_onto_white():
+    """Pillow's convert("RGB") does not composite transparent pixels against anything - it just
+    drops the alpha channel and keeps whatever RGB value was stored underneath, which can leave
+    visible phantom colors where transparency was meant to show through."""
+    rgba = Image.new("RGBA", (2, 2), (255, 255, 255, 0))  # fully transparent white
+    rgba.putpixel((0, 0), (0, 0, 0, 255))  # opaque black - must stay black
+    rgba.putpixel((1, 1), (10, 20, 30, 0))  # fully transparent, garbage RGB - must become white
+    buffer = io.BytesIO()
+    rgba.save(buffer, format="PNG")
+
+    result = imageutil.reencode_image_as_data_uri(buffer.getvalue(), max_dimension=1200)
+
+    embedded = _decode(result)
+    assert embedded.mode == "RGB"
+    assert embedded.getpixel((0, 0)) == (0, 0, 0)
+    assert embedded.getpixel((1, 1)) == (255, 255, 255)
+
+
+def test_grayscale_image_is_left_as_grayscale():
+    grayscale = _image_bytes("PNG", mode="L", size=(6, 6))
+
+    result = imageutil.reencode_image_as_data_uri(grayscale, max_dimension=1200)
+
+    assert _decode(result).mode == "L"
+
+
+def test_quality_parameter_is_honored():
+    # A flat color compresses about as well at any quality level - use noise so the JPEG quality
+    # setting actually has DCT detail to trade off against.
+    import random
+
+    random.seed(0)
+    noisy = Image.new("RGB", (60, 60))
+    noisy.putdata([tuple(random.randint(0, 255) for _ in range(3)) for _ in range(60 * 60)])
+    buffer = io.BytesIO()
+    noisy.save(buffer, format="PNG")
+    photo = buffer.getvalue()
+
+    low = imageutil.reencode_image_as_data_uri(photo, max_dimension=1200, quality=10)
+    high = imageutil.reencode_image_as_data_uri(photo, max_dimension=1200, quality=95)
+
+    assert len(low) < len(high)

--- a/goosepaper/storyprovider/test_rss.py
+++ b/goosepaper/storyprovider/test_rss.py
@@ -1,7 +1,25 @@
+import base64
 import datetime
+import io
 from types import SimpleNamespace
 
+from PIL import Image
+
 from . import rss
+
+
+def _image_bytes(fmt: str, mode: str = "RGB", size=(4, 3), color=(200, 50, 10)) -> bytes:
+    image = Image.new(mode, size, color if mode != "L" else 128)
+    buffer = io.BytesIO()
+    image.save(buffer, format=fmt)
+    return buffer.getvalue()
+
+
+def _decode_data_uri_image(html: str) -> Image.Image:
+    prefix = "data:image/jpeg;base64,"
+    start = html.index(prefix) + len(prefix)
+    end = html.index('"', start)
+    return Image.open(io.BytesIO(base64.b64decode(html[start:end])))
 
 
 def _feed_entry(
@@ -46,6 +64,10 @@ class _FakeResponse:
         self.content = content
         self.encoding = encoding
         self.url = url
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise rss.requests.HTTPError(f"{self.url} returned an error status")
 
 
 def test_rss_provider_prefers_embedded_feed_content(monkeypatch):
@@ -464,3 +486,156 @@ def test_rss_provider_can_show_only_first_byline(monkeypatch):
 
     assert stories[0].byline == "example.com"
     assert stories[1].byline is None
+
+
+class TestReencodeImageAsDataUri:
+    """Direct tests of the Pillow re-encode step, decoupled from HTTP - the actual download is
+    exercised separately in TestInlineRemoteImages."""
+
+    def test_oversized_image_is_downscaled(self):
+        oversized = _image_bytes("PNG", size=(2800, 2000))
+
+        result = rss._reencode_image_as_data_uri(oversized, rss._MAX_IMAGE_DIMENSION)
+
+        embedded = _decode_data_uri_image(f'<img src="{result}">')
+        assert max(embedded.size) == rss._MAX_IMAGE_DIMENSION
+        # Aspect ratio preserved: 2800x2000 is 1.4:1.
+        assert embedded.size == (1200, int(2000 * 1200 / 2800))
+
+    def test_cmyk_jpeg_is_converted_to_rgb_jpeg(self):
+        """Regression test: some sources (e.g. certain CDNs) serve CMYK-mode JPEGs. Passing those
+        through to WeasyPrint unmodified is a known way to make it silently drop the *entire*
+        story - see _inline_remote_images' docstring."""
+        cmyk_jpeg = _image_bytes("JPEG", mode="CMYK", size=(8, 8))
+
+        result = rss._reencode_image_as_data_uri(cmyk_jpeg, rss._MAX_IMAGE_DIMENSION)
+
+        embedded = _decode_data_uri_image(f'<img src="{result}">')
+        assert embedded.format == "JPEG"
+        assert embedded.mode in ("RGB", "L")
+
+    def test_transparent_image_is_composited_onto_white(self):
+        """Pillow's convert("RGB") does not composite transparent pixels against anything - it
+        just drops the alpha channel and keeps whatever RGB value was stored underneath, which
+        can leave visible phantom colors where transparency was meant to show through."""
+        rgba = Image.new("RGBA", (2, 2), (255, 255, 255, 0))  # fully transparent white
+        rgba.putpixel((0, 0), (0, 0, 0, 255))  # opaque black - must stay black
+        rgba.putpixel((1, 1), (10, 20, 30, 0))  # fully transparent, garbage RGB - must become white
+        buffer = io.BytesIO()
+        rgba.save(buffer, format="PNG")
+
+        result = rss._reencode_image_as_data_uri(buffer.getvalue(), rss._MAX_IMAGE_DIMENSION)
+
+        embedded = _decode_data_uri_image(f'<img src="{result}">')
+        assert embedded.mode == "RGB"
+        assert embedded.getpixel((0, 0)) == (0, 0, 0)
+        assert embedded.getpixel((1, 1)) == (255, 255, 255)
+
+
+class TestInlineRemoteImages:
+    def test_inlines_a_remote_http_image_as_a_data_uri(self, monkeypatch):
+        fake_png = _image_bytes("PNG", size=(5, 4))
+        seen_urls = []
+
+        def fake_get(url, *, headers, timeout):
+            seen_urls.append(url)
+            return _FakeResponse(ok=True, content=fake_png)
+
+        monkeypatch.setattr(rss.requests, "get", fake_get)
+
+        result = rss._inline_remote_images(
+            '<p>hello</p><img src="https://example.com/photo.jpg">'
+        )
+
+        assert seen_urls == ["https://example.com/photo.jpg"]
+        assert "data:image/jpeg;base64," in result
+        assert "https://example.com/photo.jpg" not in result
+        embedded = _decode_data_uri_image(result)
+        assert embedded.size == (5, 4)
+
+    def test_leaves_data_uri_images_untouched(self, monkeypatch):
+        def fail_get(*args, **kwargs):
+            raise AssertionError("requests.get should not run for an already-inlined image")
+
+        monkeypatch.setattr(rss.requests, "get", fail_get)
+
+        html = '<img src="data:image/png;base64,aGVsbG8=">'
+        assert rss._inline_remote_images(html) == html
+
+    def test_leaves_non_http_images_untouched(self, monkeypatch):
+        def fail_get(*args, **kwargs):
+            raise AssertionError("requests.get should not run for a src-less/non-http <img>")
+
+        monkeypatch.setattr(rss.requests, "get", fail_get)
+
+        html = "<p>no images here</p>"
+        assert rss._inline_remote_images(html) == html
+
+    def test_a_failing_image_download_leaves_that_image_as_the_original_link(self, monkeypatch):
+        """Regression test for the actual production bug this whole function fixes: an image
+        that WeasyPrint can't handle used to silently take the *entire story* down with it (see
+        _inline_remote_images' docstring). One bad image must not prevent every other image in
+        the same body from still being inlined, and must not raise out of this function."""
+
+        def fake_get(url, *, headers, timeout):
+            if "broken" in url:
+                return _FakeResponse(ok=False, content=b"")
+            return _FakeResponse(ok=True, content=_image_bytes("PNG", size=(3, 3)))
+
+        monkeypatch.setattr(rss.requests, "get", fake_get)
+
+        html = (
+            '<img src="https://example.com/broken.jpg">'
+            '<img src="https://example.com/fine.jpg">'
+        )
+        result = rss._inline_remote_images(html)
+
+        assert 'src="https://example.com/broken.jpg"' in result
+        assert "data:image/jpeg;base64," in result
+
+    def test_a_corrupt_image_body_also_leaves_the_original_link(self, monkeypatch):
+        monkeypatch.setattr(
+            rss.requests,
+            "get",
+            lambda *a, **k: _FakeResponse(ok=True, content=b"not actually an image"),
+        )
+
+        html = '<img src="https://example.com/corrupt.jpg">'
+        result = rss._inline_remote_images(html)
+
+        assert result == html
+
+    def test_get_stories_inlines_images_found_in_the_extracted_article_body(self, monkeypatch):
+        """End-to-end: an <img> that readability extracts from a fetched article page ends up
+        rewritten to a data: URI in the final Story, exercising get_stories()'s own wiring of
+        _inline_remote_images rather than calling it directly."""
+        fake_png = _image_bytes("PNG", size=(6, 5))
+
+        class FakeDocument:
+            def __init__(self, html):
+                pass
+
+            def title(self):
+                return "Readable title"
+
+            def summary(self):
+                return '<img src="https://example.com/article-photo.jpg">'
+
+        def fake_get(url, *, headers, timeout=None):
+            if url == "https://example.com/article-photo.jpg":
+                return _FakeResponse(ok=True, content=fake_png)
+            return _FakeResponse(ok=True, text="<html></html>")
+
+        monkeypatch.setattr(
+            rss.feedparser,
+            "parse",
+            lambda _: SimpleNamespace(entries=[_feed_entry(summary=None)]),
+        )
+        monkeypatch.setattr(rss.requests, "get", fake_get)
+        monkeypatch.setattr(rss, "Document", FakeDocument)
+
+        provider = rss.RSSFeedStoryProvider("https://example.com/feed.xml")
+        stories = provider.get_stories()
+
+        assert "data:image/jpeg;base64," in stories[0].body_html
+        assert "https://example.com/article-photo.jpg" not in stories[0].body_html

--- a/goosepaper/storyprovider/test_rss.py
+++ b/goosepaper/storyprovider/test_rss.py
@@ -488,51 +488,11 @@ def test_rss_provider_can_show_only_first_byline(monkeypatch):
     assert stories[1].byline is None
 
 
-class TestReencodeImageAsDataUri:
-    """Direct tests of the Pillow re-encode step, decoupled from HTTP - the actual download is
-    exercised separately in TestInlineRemoteImages."""
-
-    def test_oversized_image_is_downscaled(self):
-        oversized = _image_bytes("PNG", size=(2800, 2000))
-
-        result = rss._reencode_image_as_data_uri(oversized, rss._MAX_IMAGE_DIMENSION)
-
-        embedded = _decode_data_uri_image(f'<img src="{result}">')
-        assert max(embedded.size) == rss._MAX_IMAGE_DIMENSION
-        # Aspect ratio preserved: 2800x2000 is 1.4:1.
-        assert embedded.size == (1200, int(2000 * 1200 / 2800))
-
-    def test_cmyk_jpeg_is_converted_to_rgb_jpeg(self):
-        """Regression test: some sources (e.g. certain CDNs) serve CMYK-mode JPEGs. Passing those
-        through to WeasyPrint unmodified is a known way to make it silently drop the *entire*
-        story - see _inline_remote_images' docstring."""
-        cmyk_jpeg = _image_bytes("JPEG", mode="CMYK", size=(8, 8))
-
-        result = rss._reencode_image_as_data_uri(cmyk_jpeg, rss._MAX_IMAGE_DIMENSION)
-
-        embedded = _decode_data_uri_image(f'<img src="{result}">')
-        assert embedded.format == "JPEG"
-        assert embedded.mode in ("RGB", "L")
-
-    def test_transparent_image_is_composited_onto_white(self):
-        """Pillow's convert("RGB") does not composite transparent pixels against anything - it
-        just drops the alpha channel and keeps whatever RGB value was stored underneath, which
-        can leave visible phantom colors where transparency was meant to show through."""
-        rgba = Image.new("RGBA", (2, 2), (255, 255, 255, 0))  # fully transparent white
-        rgba.putpixel((0, 0), (0, 0, 0, 255))  # opaque black - must stay black
-        rgba.putpixel((1, 1), (10, 20, 30, 0))  # fully transparent, garbage RGB - must become white
-        buffer = io.BytesIO()
-        rgba.save(buffer, format="PNG")
-
-        result = rss._reencode_image_as_data_uri(buffer.getvalue(), rss._MAX_IMAGE_DIMENSION)
-
-        embedded = _decode_data_uri_image(f'<img src="{result}">')
-        assert embedded.mode == "RGB"
-        assert embedded.getpixel((0, 0)) == (0, 0, 0)
-        assert embedded.getpixel((1, 1)) == (255, 255, 255)
-
-
 class TestInlineRemoteImages:
+    """Wiring tests: does _inline_remote_images fetch the right URLs, skip the right ones, and
+    tolerate a failure without losing the rest? The actual Pillow re-encode step it delegates to
+    (size capping, CMYK/transparency handling) has its own direct tests in test_imageutil.py."""
+
     def test_inlines_a_remote_http_image_as_a_data_uri(self, monkeypatch):
         fake_png = _image_bytes("PNG", size=(5, 4))
         seen_urls = []


### PR DESCRIPTION
## What

RSS article images are embedded exactly as the source served them - a remote `<img src>` that WeasyPrint fetches and decodes itself while rendering the PDF, with zero control over what it gets. That reproduces a known WeasyPrint failure mode (already diagnosed and fixed for comic strips elsewhere, see #133): certain source images - oversized, wrong color mode, an unsupported format - make it silently drop the *entire* story, not just the image. No exception, no log line.

## Evidence

Verified against a real daily edition (110 stories, 26 feeds): 28 of 53 embedded images failed to make it into the rendered PDF. Every failing case traced back to the source image itself:
- multi-megapixel photos (up to 4000px, 500KB-1.4MB)
- a palette-mode PNG encoding photo-like content far less efficiently than JPEG
- WebP files - a format WeasyPrint's image backend can't decode at all, independent of size

## Fix

`_inline_remote_images` fetches each `<img src="http(s)://...">` found in a story's assembled `body_html`, decodes and re-encodes it through Pillow (bound dimensions, normalize color mode, composite transparency onto white, always emit JPEG), and inlines the result as a `data:` URI instead of the original remote link. An image that fails to download or decode is left as its original remote link rather than aborting the whole story.

The re-encode step itself (`storyprovider/imageutil.py`) is a small shared module, not RSS-specific - see the note below.

## Testing

- New `test_imageutil.py`: direct tests of the re-encode step (oversized downscaling, CMYK->RGB, transparency composited onto white, grayscale preserved, JPEG quality honored).
- New `TestInlineRemoteImages` in `test_rss.py`: wiring tests (fetches the right URLs, skips `data:`/non-http images, tolerates a failing download without losing the rest of the story or the other images in it, end-to-end through `get_stories()`).
- Full test suite passes (109/109).
- `flake8` clean (both the syntax-error pass and the full statistics pass CI runs).

## Note: shares `imageutil.py` with #133

Comic strip images (#133) need the identical re-encode step, for the identical reason, and previously had their own separate bespoke copy of this logic. Both PRs now use the same `storyprovider/imageutil.py` - each carries its own copy of the file so neither depends on the other merging first; whichever merges second will see, at worst, a trivial identical-content conflict on that one file.

## Honesty note on scope

This fix makes image *encoding* itself reliable (0 failures out of 53 in the verification run, one intentional exception: a source SVG, which isn't a raster format Pillow can decode, left as its original link). It measurably reduces a real daily edition's total rendered size (~31% smaller in testing) and removes per-image failure as a variable. It does **not** by itself guarantee every story in a very large, image-heavy edition survives - that also depends on the document's total combined weight, a separate, document-wide WeasyPrint behavior not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
